### PR TITLE
otlpgrpc exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+env:
+  # Path to where test results will be saved.
+  TEST_RESULTS: /tmp/test-results
+  # Default version of Go to use by CI workflows. This should be the latest
+  # release of Go; developers likely use the latest release in development and
+  # we want to catch any bugs (e.g. lint errors, race detection) with this
+  # release before they are merged. The Go compatibility guarantees ensure
+  # backwards compatibility with the previous two minor releases and we
+  # explicitly test our code for these versions so keeping this at prior
+  # versions does not add value.
+  DEFAULT_GO_VERSION: "1.20"
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+      - name: Run coverage tests
+        run: |
+          make test-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
+coverage.txt
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test-coverage
+
+test-coverage:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ this API to bridge between existing logging libraries and the OpenTelemetry log 
 Example bellow will show how logging library could be instrumented with current API:
 
 ```go
+package myInstrumentedLogger
+
+import (
+	otel "github.com/agoda-com/opentelemetry-logs-go"
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+)
 
 const (
   instrumentationName = "otel/zap"
@@ -46,7 +53,7 @@ func (c otlpCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
     Body: &ent.Message,
 	...
   }
-  logRecord := logs.NewLogRecord(cfg)
+  logRecord := logs.NewLogRecord(lrc)
   logger.Emit(logRecord)
 }
 ```
@@ -77,8 +84,9 @@ func newResource() *resource.Resource {
 func main() {
 	ctx := context.Background()
 
+	exporter, _ := otlplogs.New(ctx, otlplogshttp.NewClient())
 	loggerProvider := sdk.NewLoggerProvider(
-		sdk.WithBatcher(otlplogs.New(ctx, otlplogshttp.NewClient())),
+		sdk.WithBatcher(exporter),
 		sdk.WithResource(newResource()),
 	)
 	otel.SetLoggerProvider(loggerProvider)

--- a/exporters/otlp/internal/partialsuccess.go
+++ b/exporters/otlp/internal/partialsuccess.go
@@ -38,11 +38,11 @@ func (ps PartialSuccess) Error() string {
 var _ error = PartialSuccess{}
 
 // LogRecordPartialSuccessError returns an error describing a partial success
-// response for the trace signal.
+// response for the log signal.
 func LogRecordPartialSuccessError(itemsRejected int64, errorMessage string) error {
 	return PartialSuccess{
 		ErrorMessage:  errorMessage,
 		RejectedItems: itemsRejected,
-		RejectedKind:  "spans",
+		RejectedKind:  "logs",
 	}
 }

--- a/exporters/otlp/otlplogs/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlplogs/internal/otlpconfig/options.go
@@ -33,10 +33,10 @@ import (
 
 const (
 	// DefaultLogsPath is a default URL path for endpoint that
-	// receives spans.
+	// receives logs.
 	DefaultLogsPath string = "/v1/logs"
 	// DefaultTimeout is a default max waiting time for the backend to process
-	// each span batch.
+	// each logs batch.
 	DefaultTimeout time.Duration = 10 * time.Second
 )
 

--- a/exporters/otlp/otlplogs/internal/otlplogstest/client.go
+++ b/exporters/otlp/otlplogs/internal/otlplogstest/client.go
@@ -1,0 +1,135 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlplogstest
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
+)
+
+func RunExporterShutdownTest(t *testing.T, factory func() otlplogs.Client) {
+	t.Run("testClientStopHonorsTimeout", func(t *testing.T) {
+		testClientStopHonorsTimeout(t, factory())
+	})
+
+	t.Run("testClientStopHonorsCancel", func(t *testing.T) {
+		testClientStopHonorsCancel(t, factory())
+	})
+
+	t.Run("testClientStopNoError", func(t *testing.T) {
+		testClientStopNoError(t, factory())
+	})
+
+	t.Run("testClientStopManyTimes", func(t *testing.T) {
+		testClientStopManyTimes(t, factory())
+	})
+}
+
+func initializeExporter(t *testing.T, client otlplogs.Client) *otlplogs.Exporter {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	e, err := otlplogs.New(ctx, client)
+	if err != nil {
+		t.Fatalf("failed to create exporter")
+	}
+
+	return e
+}
+
+func testClientStopHonorsTimeout(t *testing.T, client otlplogs.Client) {
+	t.Cleanup(func() {
+		// The test is looking for a failed shut down. Call Stop a second time
+		// with an un-expired context to give the client a second chance at
+		// cleaning up. There is not guarantee from the Client interface this
+		// will succeed, therefore, no need to check the error (just give it a
+		// best try).
+		_ = client.Stop(context.Background())
+	})
+	e := initializeExporter(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	if err := e.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context DeadlineExceeded error, got %v", err)
+	}
+}
+
+func testClientStopHonorsCancel(t *testing.T, client otlplogs.Client) {
+	t.Cleanup(func() {
+		// The test is looking for a failed shut down. Call Stop a second time
+		// with an un-expired context to give the client a second chance at
+		// cleaning up. There is not guarantee from the Client interface this
+		// will succeed, therefore, no need to check the error (just give it a
+		// best try).
+		_ = client.Stop(context.Background())
+	})
+	e := initializeExporter(t, client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := e.Shutdown(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context canceled error, got %v", err)
+	}
+}
+
+func testClientStopNoError(t *testing.T, client otlplogs.Client) {
+	e := initializeExporter(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	if err := e.Shutdown(ctx); err != nil {
+		t.Errorf("shutdown errored: expected nil, got %v", err)
+	}
+}
+
+func testClientStopManyTimes(t *testing.T, client otlplogs.Client) {
+	e := initializeExporter(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	ch := make(chan struct{})
+	wg := sync.WaitGroup{}
+	const num int = 20
+	wg.Add(num)
+	errs := make([]error, num)
+	for i := 0; i < num; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-ch
+			errs[idx] = e.Shutdown(ctx)
+		}(i)
+	}
+	close(ch)
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Errorf("failed to shutdown exporter: %v", err)
+			return
+		}
+	}
+}

--- a/exporters/otlp/otlplogs/internal/otlplogstest/collector.go
+++ b/exporters/otlp/otlplogs/internal/otlplogstest/collector.go
@@ -1,0 +1,105 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlplogstest
+
+import (
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	"sort"
+
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+// LogsCollector mocks a collector for the end-to-end testing.
+type LogsCollector interface {
+	Stop() error
+	GetResourceLogs() []*logspb.ResourceLogs
+}
+
+// LogsStorage stores the Logs. Mock collectors can use it to
+// store logs they have received.
+type LogsStorage struct {
+	rlm       map[string]*logspb.ResourceLogs
+	logsCount int
+}
+
+// NewLogsStorage creates a new logs storage.
+func NewLogsStorage() LogsStorage {
+	return LogsStorage{
+		rlm: make(map[string]*logspb.ResourceLogs),
+	}
+}
+
+// AddLogs adds logs to the logs storage.
+func (s *LogsStorage) AddLogs(request *collectorlogspb.ExportLogsServiceRequest) {
+	for _, rs := range request.GetResourceLogs() {
+		rstr := resourceString(rs.Resource)
+		if existingRs, ok := s.rlm[rstr]; !ok {
+			s.rlm[rstr] = rs
+			// TODO (rghetia): Add support for library Info.
+			if len(rs.ScopeLogs) == 0 {
+				rs.ScopeLogs = []*logspb.ScopeLogs{
+					{
+						LogRecords: []*logspb.LogRecord{},
+					},
+				}
+			}
+			s.logsCount += len(rs.ScopeLogs[0].LogRecords)
+		} else {
+			if len(rs.ScopeLogs) > 0 {
+				newLogs := rs.ScopeLogs[0].GetLogRecords()
+				existingRs.ScopeLogs[0].LogRecords = append(existingRs.ScopeLogs[0].LogRecords, newLogs...)
+				s.logsCount += len(newLogs)
+			}
+		}
+	}
+}
+
+// GetLogRecords returns the stored logs.
+func (s *LogsStorage) GetLogRecords() []*logspb.LogRecord {
+	logs := make([]*logspb.LogRecord, 0, s.logsCount)
+	for _, rs := range s.rlm {
+		logs = append(logs, rs.ScopeLogs[0].LogRecords...)
+	}
+	return logs
+}
+
+// GetResourceLogs returns the stored resource logs.
+func (s *LogsStorage) GetResourceLogs() []*logspb.ResourceLogs {
+	rls := make([]*logspb.ResourceLogs, 0, len(s.rlm))
+	for _, rs := range s.rlm {
+		rls = append(rls, rs)
+	}
+	return rls
+}
+
+func resourceString(res *resourcepb.Resource) string {
+	sAttrs := sortedAttributes(res.GetAttributes())
+	rstr := ""
+	for _, attr := range sAttrs {
+		rstr = rstr + attr.String()
+	}
+	return rstr
+}
+
+func sortedAttributes(attrs []*commonpb.KeyValue) []*commonpb.KeyValue {
+	sort.Slice(attrs[:], func(i, j int) bool {
+		return attrs[i].Key < attrs[j].Key
+	})
+	return attrs
+}

--- a/exporters/otlp/otlplogs/internal/otlplogstest/data.go
+++ b/exporters/otlp/otlplogs/internal/otlplogstest/data.go
@@ -1,0 +1,43 @@
+package otlplogstest
+
+import (
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	logssdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"github.com/agoda-com/opentelemetry-logs-go/sdk/logs/logstest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
+	"time"
+)
+
+func SingleReadableLogRecord() []logssdk.ReadableLogRecord {
+
+	time := time.Now()
+	tid := trace.TraceID{2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6, 7, 8, 9}
+	sid := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+	tf := trace.FlagsSampled
+	body := "TestMessage"
+	is := instrumentation.Scope{
+		Name:    "bar",
+		Version: "0.0.0",
+	}
+	st := "INFO"
+	sn := logs.INFO
+
+	return logstest.LogRecordStubs{
+		logstest.LogRecordStub{
+			Timestamp:            &time,
+			ObservedTimestamp:    time,
+			TraceId:              &tid,
+			SpanId:               &sid,
+			TraceFlags:           &tf,
+			SeverityText:         &st,
+			SeverityNumber:       &sn,
+			Body:                 &body,
+			Resource:             resource.NewSchemaless(attribute.String("a", "b")),
+			InstrumentationScope: &is,
+			Attributes:           &[]attribute.KeyValue{},
+		},
+	}.Snapshots()
+}

--- a/exporters/otlp/otlplogs/internal/otlplogstest/otlptest.go
+++ b/exporters/otlp/otlplogs/internal/otlplogstest/otlptest.go
@@ -1,0 +1,117 @@
+package otlplogstest
+
+import (
+	"context"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	sdklogs "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// RunEndToEndTest can be used by otlplogs.Client tests to validate
+// themselves.
+func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlplogs.Exporter, logsCollector LogsCollector) {
+	pOpts := []sdklogs.LoggerProviderOption{
+		sdklogs.WithBatcher(
+			exp,
+			// add following two options to ensure flush
+			//sdklogs.WithBatchTimeout(5*time.Second),
+			//	sdklogs.WithMaxExportBatchSize(10),
+		),
+	}
+	tp1 := sdklogs.NewLoggerProvider(append(pOpts,
+		sdklogs.WithResource(resource.NewSchemaless(
+			attribute.String("rk1", "rv11)"),
+			attribute.Int64("rk2", 5),
+		)))...)
+
+	tp2 := sdklogs.NewLoggerProvider(append(pOpts,
+		sdklogs.WithResource(resource.NewSchemaless(
+			attribute.String("rk1", "rv12)"),
+			attribute.Float64("rk3", 6.5),
+		)))...)
+
+	tr1 := tp1.Logger("test-logger1")
+	tr2 := tp2.Logger("test-logger2")
+	// Now create few logs
+	m := 4
+	body := "TestLog"
+	for i := 0; i < m; i++ {
+		lr1 := logs.NewLogRecord(logs.LogRecordConfig{
+			Body:       &body,
+			Attributes: &[]attribute.KeyValue{attribute.Int64("i", int64(i))},
+		})
+		tr1.Emit(lr1)
+
+		lr2 := logs.NewLogRecord(logs.LogRecordConfig{
+			Body:       &body,
+			Attributes: &[]attribute.KeyValue{attribute.Int64("i", int64(i))},
+		})
+
+		tr2.Emit(lr2)
+	}
+
+	func() {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		if err := tp1.Shutdown(ctx); err != nil {
+			t.Fatalf("failed to shut down a logger provider 1: %v", err)
+		}
+		if err := tp2.Shutdown(ctx); err != nil {
+			t.Fatalf("failed to shut down a logger provider 2: %v", err)
+		}
+	}()
+
+	// Wait >2 cycles.
+	<-time.After(40 * time.Millisecond)
+
+	// Now shutdown the exporter
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := exp.Shutdown(ctx); err != nil {
+		t.Fatalf("failed to stop the exporter: %v", err)
+	}
+
+	// Shutdown the collector too so that we can begin
+	// verification checks of expected data back.
+	if err := logsCollector.Stop(); err != nil {
+		t.Fatalf("failed to stop the mock collector: %v", err)
+	}
+
+	// Now verify that we only got two resources
+	rss := logsCollector.GetResourceLogs()
+	if got, want := len(rss), 2; got != want {
+		t.Fatalf("resource log count: got %d, want %d\n", got, want)
+	}
+
+	// Now verify logs and attributes for each resource log.
+	for _, rs := range rss {
+		if len(rs.ScopeLogs) == 0 {
+			t.Fatalf("zero ScopeLogs")
+		}
+		if got, want := len(rs.ScopeLogs[0].LogRecords), m; got != want {
+			t.Fatalf("log counts: got %d, want %d", got, want)
+		}
+		attrMap := map[int64]bool{}
+		for _, s := range rs.ScopeLogs[0].LogRecords {
+			if gotName, want := s.Body.GetStringValue(), "TestLog"; gotName != want {
+				t.Fatalf("log name: got %s, want %s", gotName, want)
+			}
+			attrMap[s.Attributes[0].Value.Value.(*commonpb.AnyValue_IntValue).IntValue] = true
+		}
+		if got, want := len(attrMap), m; got != want {
+			t.Fatalf("log attribute unique values: got %d  want %d", got, want)
+		}
+		for i := 0; i < m; i++ {
+			_, ok := attrMap[int64(i)]
+			if !ok {
+				t.Fatalf("log with attribute %d missing", i)
+			}
+		}
+	}
+}

--- a/exporters/otlp/otlplogs/internal/otlplogstest/otlptest.go
+++ b/exporters/otlp/otlplogs/internal/otlplogstest/otlptest.go
@@ -20,8 +20,8 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlplogs.Exporter, 
 		sdklogs.WithBatcher(
 			exp,
 			// add following two options to ensure flush
-			//sdklogs.WithBatchTimeout(5*time.Second),
-			//	sdklogs.WithMaxExportBatchSize(10),
+			sdklogs.WithBatchTimeout(5*time.Second),
+			sdklogs.WithMaxExportBatchSize(10),
 		),
 	}
 	tp1 := sdklogs.NewLoggerProvider(append(pOpts,

--- a/exporters/otlp/otlplogs/otlplogsgrpc/client.go
+++ b/exporters/otlp/otlplogs/otlplogsgrpc/client.go
@@ -1,0 +1,301 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlplogsgrpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	internal "github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/internal"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/otlpconfig"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/retry"
+
+	"go.opentelemetry.io/otel"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type client struct {
+	endpoint      string
+	dialOpts      []grpc.DialOption
+	metadata      metadata.MD
+	exportTimeout time.Duration
+	requestFunc   retry.RequestFunc
+
+	// stopCtx is used as a parent context for all exports. Therefore, when it
+	// is canceled with the stopFunc all exports are canceled.
+	stopCtx context.Context
+	// stopFunc cancels stopCtx, stopping any active exports.
+	stopFunc context.CancelFunc
+
+	// ourConn keeps track of where conn was created: true if created here on
+	// Start, or false if passed with an option. This is important on Shutdown
+	// as the conn should only be closed if created here on start. Otherwise,
+	// it is up to the processes that passed the conn to close it.
+	ourConn bool
+	conn    *grpc.ClientConn
+	tscMu   sync.RWMutex
+	tsc     collogspb.LogsServiceClient
+}
+
+// Compile time check *client implements otlplogs.Client.
+var _ otlplogs.Client = (*client)(nil)
+
+// NewClient creates a new gRPC logs client.
+func NewClient(opts ...Option) otlplogs.Client {
+	return newClient(opts...)
+}
+
+func newClient(opts ...Option) *client {
+	cfg := otlpconfig.NewGRPCConfig(asGRPCOptions(opts)...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &client{
+		endpoint:      cfg.Logs.Endpoint,
+		exportTimeout: cfg.Logs.Timeout,
+		requestFunc:   cfg.RetryConfig.RequestFunc(retryable),
+		dialOpts:      cfg.DialOptions,
+		stopCtx:       ctx,
+		stopFunc:      cancel,
+		conn:          cfg.GRPCConn,
+	}
+
+	if len(cfg.Logs.Headers) > 0 {
+		c.metadata = metadata.New(cfg.Logs.Headers)
+	}
+
+	return c
+}
+
+// Start establishes a gRPC connection to the collector.
+func (c *client) Start(ctx context.Context) error {
+	if c.conn == nil {
+		// If the caller did not provide a ClientConn when the client was
+		// created, create one using the configuration they did provide.
+		conn, err := grpc.DialContext(ctx, c.endpoint, c.dialOpts...)
+		if err != nil {
+			return err
+		}
+		// Keep track that we own the lifecycle of this conn and need to close
+		// it on Shutdown.
+		c.ourConn = true
+		c.conn = conn
+	}
+
+	// The otlplogs.Client interface states this method is called just once,
+	// so no need to check if already started.
+	c.tscMu.Lock()
+	c.tsc = collogspb.NewLogsServiceClient(c.conn)
+	c.tscMu.Unlock()
+
+	return nil
+}
+
+var errAlreadyStopped = errors.New("the client is already stopped")
+
+// Stop shuts down the client.
+//
+// Any active connections to a remote endpoint are closed if they were created
+// by the client. Any gRPC connection passed during creation using
+// WithGRPCConn will not be closed. It is the caller's responsibility to
+// handle cleanup of that resource.
+//
+// This method synchronizes with the UploadLogs method of the client. It
+// will wait for any active calls to that method to complete unimpeded, or it
+// will cancel any active calls if ctx expires. If ctx expires, the context
+// error will be forwarded as the returned error. All client held resources
+// will still be released in this situation.
+//
+// If the client has already stopped, an error will be returned describing
+// this.
+func (c *client) Stop(ctx context.Context) error {
+	// Make sure to return context error if the context is done when calling this method.
+	err := ctx.Err()
+
+	// Acquire the c.tscMu lock within the ctx lifetime.
+	acquired := make(chan struct{})
+	go func() {
+		c.tscMu.Lock()
+		close(acquired)
+	}()
+
+	select {
+	case <-ctx.Done():
+		// The Stop timeout is reached. Kill any remaining exports to force
+		// the clear of the lock and save the timeout error to return and
+		// signal the shutdown timed out before cleanly stopping.
+		c.stopFunc()
+		err = ctx.Err()
+
+		// To ensure the client is not left in a dirty state c.tsc needs to be
+		// set to nil. To avoid the race condition when doing this, ensure
+		// that all the exports are killed (initiated by c.stopFunc).
+		<-acquired
+	case <-acquired:
+	}
+	// Hold the tscMu lock for the rest of the function to ensure no new
+	// exports are started.
+	defer c.tscMu.Unlock()
+
+	// The otlplogs.Client interface states this method is called only
+	// once, but there is no guarantee it is called after Start. Ensure the
+	// client is started before doing anything and let the called know if they
+	// made a mistake.
+	if c.tsc == nil {
+		return errAlreadyStopped
+	}
+
+	// Clear c.tsc to signal the client is stopped.
+	c.tsc = nil
+
+	if c.ourConn {
+		closeErr := c.conn.Close()
+		// A context timeout error takes precedence over this error.
+		if err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}
+	return err
+}
+
+var errShutdown = errors.New("the client is shutdown")
+
+// UploadLogs sends log records.
+//
+// Retryable errors from the server will be handled according to any
+// RetryConfig the client was created with.
+func (c *client) UploadLogs(ctx context.Context, protoLogs []*logspb.ResourceLogs) error {
+	// Hold a read lock to ensure a shut down initiated after this starts does
+	// not abandon the export. This read lock acquire has less priority than a
+	// write lock acquire (i.e. Stop), meaning if the client is shutting down
+	// this will come after the shut down.
+	c.tscMu.RLock()
+	defer c.tscMu.RUnlock()
+
+	if c.tsc == nil {
+		return errShutdown
+	}
+
+	ctx, cancel := c.exportContext(ctx)
+	defer cancel()
+
+	return c.requestFunc(ctx, func(iCtx context.Context) error {
+		resp, err := c.tsc.Export(iCtx, &collogspb.ExportLogsServiceRequest{
+			ResourceLogs: protoLogs,
+		})
+		if resp != nil && resp.PartialSuccess != nil {
+			msg := resp.PartialSuccess.GetErrorMessage()
+			n := resp.PartialSuccess.GetRejectedLogRecords()
+			if n != 0 || msg != "" {
+				err := internal.LogRecordPartialSuccessError(n, msg)
+				otel.Handle(err)
+			}
+		}
+		// nil is converted to OK.
+		if status.Code(err) == codes.OK {
+			// Success.
+			return nil
+		}
+		return err
+	})
+}
+
+// exportContext returns a copy of parent with an appropriate deadline and
+// cancellation function.
+//
+// It is the callers responsibility to cancel the returned context once its
+// use is complete, via the parent or directly with the returned CancelFunc, to
+// ensure all resources are correctly released.
+func (c *client) exportContext(parent context.Context) (context.Context, context.CancelFunc) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	if c.exportTimeout > 0 {
+		ctx, cancel = context.WithTimeout(parent, c.exportTimeout)
+	} else {
+		ctx, cancel = context.WithCancel(parent)
+	}
+
+	if c.metadata.Len() > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, c.metadata)
+	}
+
+	// Unify the client stopCtx with the parent.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-c.stopCtx.Done():
+			// Cancel the export as the shutdown has timed out.
+			cancel()
+		}
+	}()
+
+	return ctx, cancel
+}
+
+// retryable returns if err identifies a request that can be retried and a
+// duration to wait for if an explicit throttle time is included in err.
+func retryable(err error) (bool, time.Duration) {
+	s := status.Convert(err)
+	switch s.Code() {
+	case codes.Canceled,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.OutOfRange,
+		codes.Unavailable,
+		codes.DataLoss:
+		return true, throttleDelay(s)
+	}
+
+	// Not a retry-able error.
+	return false, 0
+}
+
+// throttleDelay returns a duration to wait for if an explicit throttle time
+// is included in the response status.
+func throttleDelay(s *status.Status) time.Duration {
+	for _, detail := range s.Details() {
+		if t, ok := detail.(*errdetails.RetryInfo); ok {
+			return t.RetryDelay.AsDuration()
+		}
+	}
+	return 0
+}
+
+// MarshalLog is the marshaling function used by the logging system to represent this Client.
+func (c *client) MarshalLog() interface{} {
+	return struct {
+		Type     string
+		Endpoint string
+	}{
+		Type:     "otlphttpgrpc",
+		Endpoint: c.endpoint,
+	}
+}

--- a/exporters/otlp/otlplogs/otlplogsgrpc/client_test.go
+++ b/exporters/otlp/otlplogs/otlplogsgrpc/client_test.go
@@ -1,0 +1,418 @@
+package otlplogsgrpc_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/otlplogstest"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogsgrpc"
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	sdklogs "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"github.com/agoda-com/opentelemetry-logs-go/sdk/logs/logstest"
+	"go.opentelemetry.io/otel/sdk/resource"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/status"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+var body = "Log Record 0"
+var roLogRecords = logstest.LogRecordStubs{{Body: &body}}.Snapshots()
+
+func contextWithTimeout(parent context.Context, t *testing.T, timeout time.Duration) (context.Context, context.CancelFunc) {
+	d, ok := t.Deadline()
+	if !ok {
+		d = time.Now().Add(timeout)
+	} else {
+		d = d.Add(-1 * time.Millisecond)
+		now := time.Now()
+		if d.Sub(now) > timeout {
+			d = now.Add(timeout)
+		}
+	}
+	return context.WithDeadline(parent, d)
+}
+
+func TestNewEndToEnd(t *testing.T) {
+	tests := []struct {
+		name           string
+		additionalOpts []otlplogsgrpc.Option
+	}{
+		{
+			name: "StandardExporter",
+		},
+		{
+			name: "WithCompressor",
+			additionalOpts: []otlplogsgrpc.Option{
+				otlplogsgrpc.WithCompressor(gzip.Name),
+			},
+		},
+		{
+			name: "WithServiceConfig",
+			additionalOpts: []otlplogsgrpc.Option{
+				otlplogsgrpc.WithServiceConfig("{}"),
+			},
+		},
+		{
+			name: "WithDialOptions",
+			additionalOpts: []otlplogsgrpc.Option{
+				otlplogsgrpc.WithDialOption(grpc.WithBlock()),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newExporterEndToEndTest(t, test.additionalOpts)
+		})
+	}
+}
+
+func newGRPCExporter(t *testing.T, ctx context.Context, endpoint string, additionalOpts ...otlplogsgrpc.Option) *otlplogs.Exporter {
+	opts := []otlplogsgrpc.Option{
+		otlplogsgrpc.WithInsecure(),
+		otlplogsgrpc.WithEndpoint(endpoint),
+		otlplogsgrpc.WithReconnectionPeriod(50 * time.Millisecond),
+	}
+
+	opts = append(opts, additionalOpts...)
+	client := otlplogsgrpc.NewClient(opts...)
+	exp, err := otlplogs.New(ctx, client)
+	if err != nil {
+		t.Fatalf("failed to create a new collector exporter: %v", err)
+	}
+	return exp
+}
+
+func newExporterEndToEndTest(t *testing.T, additionalOpts []otlplogsgrpc.Option) {
+	mc := runMockCollector(t)
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint, additionalOpts...)
+	t.Cleanup(func() {
+		ctx, cancel := contextWithTimeout(ctx, t, 10*time.Second)
+		defer cancel()
+
+		require.NoError(t, exp.Shutdown(ctx))
+	})
+
+	// RunEndToEndTest closes mc.
+	otlplogstest.RunEndToEndTest(ctx, t, exp, mc)
+}
+
+func TestExporterShutdown(t *testing.T) {
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	factory := func() otlplogs.Client {
+		return otlplogsgrpc.NewClient(
+			otlplogsgrpc.WithEndpoint(mc.endpoint),
+			otlplogsgrpc.WithInsecure(),
+			otlplogsgrpc.WithDialOption(grpc.WithBlock()),
+		)
+	}
+	otlplogstest.RunExporterShutdownTest(t, factory)
+}
+
+func TestNewInvokeStartThenStopManyTimes(t *testing.T) {
+	mc := runMockCollector(t)
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	// Invoke Start numerous times, should return errAlreadyStarted
+	for i := 0; i < 10; i++ {
+		if err := exp.Start(ctx); err == nil || !strings.Contains(err.Error(), "already started") {
+			t.Fatalf("#%d unexpected Start error: %v", i, err)
+		}
+	}
+
+	if err := exp.Shutdown(ctx); err != nil {
+		t.Fatalf("failed to Shutdown the exporter: %v", err)
+	}
+	// Invoke Shutdown numerous times
+	for i := 0; i < 10; i++ {
+		if err := exp.Shutdown(ctx); err != nil {
+			t.Fatalf(`#%d got error (%v) expected none`, i, err)
+		}
+	}
+}
+
+// This test takes a long time to run: to skip it, run tests using: -short.
+func TestNewCollectorOnBadConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping this long running test")
+	}
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to grab an available port: %v", err)
+	}
+	// Firstly close the "collector's" channel: optimistically this endpoint won't get reused ASAP
+	// However, our goal of closing it is to simulate an unavailable connection
+	_ = ln.Close()
+
+	_, collectorPortStr, _ := net.SplitHostPort(ln.Addr().String())
+
+	endpoint := fmt.Sprintf("localhost:%s", collectorPortStr)
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, endpoint)
+	_ = exp.Shutdown(ctx)
+}
+
+func TestNewWithEndpoint(t *testing.T) {
+	mc := runMockCollector(t)
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint)
+	_ = exp.Shutdown(ctx)
+}
+
+func TestNewWithHeaders(t *testing.T) {
+	mc := runMockCollector(t)
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint,
+		otlplogsgrpc.WithHeaders(map[string]string{"header1": "value1"}))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+	require.NoError(t, exp.Export(ctx, roLogRecords))
+
+	headers := mc.getHeaders()
+	require.Regexp(t, "OTel OTLP Exporter Go/1\\..*", headers.Get("user-agent"))
+	require.Len(t, headers.Get("header1"), 1)
+	assert.Equal(t, "value1", headers.Get("header1")[0])
+}
+
+func TestExportLogsTimeoutHonored(t *testing.T) {
+	ctx, cancel := contextWithTimeout(context.Background(), t, 1*time.Minute)
+	t.Cleanup(cancel)
+
+	mc := runMockCollector(t)
+	exportBlock := make(chan struct{})
+	mc.logsSvc.exportBlock = exportBlock
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	exp := newGRPCExporter(
+		t,
+		ctx,
+		mc.endpoint,
+		otlplogsgrpc.WithTimeout(1*time.Nanosecond),
+		otlplogsgrpc.WithRetry(otlplogsgrpc.RetryConfig{Enabled: false}),
+	)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	err := exp.Export(ctx, roLogRecords)
+	// Release the export so everything is cleaned up on shutdown.
+	close(exportBlock)
+
+	unwrapped := errors.Unwrap(err)
+	require.Equal(t, codes.DeadlineExceeded, status.Convert(unwrapped).Code())
+	require.True(t, strings.HasPrefix(err.Error(), "logRecords export: "), err)
+}
+
+func TestNewWithMultipleAttributeTypes(t *testing.T) {
+	mc := runMockCollector(t)
+
+	ctx, cancel := contextWithTimeout(context.Background(), t, 10*time.Second)
+	t.Cleanup(cancel)
+
+	exp := newGRPCExporter(t, ctx, mc.endpoint)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	tp := sdklogs.NewLoggerProvider(
+		sdklogs.WithBatcher(
+			exp,
+			// add following two options to ensure flush
+			//	sdklogs.WithBatchTimeout(5*time.Second),
+			//	sdklogs.WithMaxExportBatchSize(10),
+		),
+	)
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(ctx)) })
+
+	tr := tp.Logger("test-logger")
+	testKvs := []attribute.KeyValue{
+		attribute.Int("Int", 1),
+		attribute.Int64("Int64", int64(3)),
+		attribute.Float64("Float64", 2.22),
+		attribute.Bool("Bool", true),
+		attribute.String("String", "test"),
+	}
+	lrc := logs.LogRecordConfig{
+		Resource: resource.NewSchemaless(testKvs...),
+	}
+
+	logRecord := logs.NewLogRecord(lrc)
+
+	tr.Emit(logRecord)
+
+	// Flush and close.
+	func() {
+		ctx, cancel := contextWithTimeout(ctx, t, 10*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	}()
+
+	// Wait >2 cycles.
+	<-time.After(40 * time.Millisecond)
+
+	// Now shutdown the exporter
+	require.NoError(t, exp.Shutdown(ctx))
+
+	// Shutdown the collector too so that we can begin
+	// verification checks of expected data back.
+	require.NoError(t, mc.stop())
+
+	// Now verify that we only got one logs
+	rss := mc.getLogRecords()
+	if got, want := len(rss), 1; got != want {
+		t.Fatalf("resource logs count: got %d, want %d\n", got, want)
+	}
+
+	expected := []*commonpb.KeyValue{
+		{
+			Key: "Int",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{
+					IntValue: 1,
+				},
+			},
+		},
+		{
+			Key: "Int64",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{
+					IntValue: 3,
+				},
+			},
+		},
+		{
+			Key: "Float64",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_DoubleValue{
+					DoubleValue: 2.22,
+				},
+			},
+		},
+		{
+			Key: "Bool",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_BoolValue{
+					BoolValue: true,
+				},
+			},
+		},
+		{
+			Key: "String",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{
+					StringValue: "test",
+				},
+			},
+		},
+	}
+
+	// Verify attributes
+	if !assert.Len(t, rss[0].Attributes, len(expected)) {
+		t.Fatalf("attributes count: got %d, want %d\n", len(rss[0].Attributes), len(expected))
+	}
+	for i, actual := range rss[0].Attributes {
+		if a, ok := actual.Value.Value.(*commonpb.AnyValue_DoubleValue); ok {
+			e, ok := expected[i].Value.Value.(*commonpb.AnyValue_DoubleValue)
+			if !ok {
+				t.Errorf("expected AnyValue_DoubleValue, got %T", expected[i].Value.Value)
+				continue
+			}
+			if !assert.InDelta(t, e.DoubleValue, a.DoubleValue, 0.01) {
+				continue
+			}
+			e.DoubleValue = a.DoubleValue
+		}
+		assert.Equal(t, expected[i], actual)
+	}
+}
+
+func TestStartErrorInvalidAddress(t *testing.T) {
+	client := otlplogsgrpc.NewClient(
+		otlplogsgrpc.WithInsecure(),
+		// Validate the connection in Start (which should return the error).
+		otlplogsgrpc.WithDialOption(
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+		),
+		otlplogsgrpc.WithEndpoint("invalid"),
+		otlplogsgrpc.WithReconnectionPeriod(time.Hour),
+	)
+	err := client.Start(context.Background())
+	assert.EqualError(t, err, `connection error: desc = "transport: error while dialing: dial tcp: address invalid: missing port in address"`)
+}
+
+func TestEmptyData(t *testing.T) {
+	mc := runMockCollector(t)
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	assert.NoError(t, exp.Export(ctx, nil))
+}
+
+func TestPartialSuccess(t *testing.T) {
+	mc := runMockCollectorWithConfig(t, &mockConfig{
+		partial: &collogspb.ExportLogsPartialSuccess{
+			RejectedLogRecords: 2,
+			ErrorMessage:       "partially successful",
+		},
+	})
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	errs := []error{}
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		errs = append(errs, err)
+	}))
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+	require.NoError(t, exp.Export(ctx, roLogRecords))
+
+	require.Equal(t, 1, len(errs))
+	require.Contains(t, errs[0].Error(), "partially successful")
+	require.Contains(t, errs[0].Error(), "2 logs rejected")
+}
+
+func TestCustomUserAgent(t *testing.T) {
+	customUserAgent := "custom-user-agent"
+	mc := runMockCollector(t)
+	t.Cleanup(func() { require.NoError(t, mc.stop()) })
+
+	ctx := context.Background()
+	exp := newGRPCExporter(t, ctx, mc.endpoint,
+		otlplogsgrpc.WithDialOption(grpc.WithUserAgent(customUserAgent)))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+	require.NoError(t, exp.Export(ctx, roLogRecords))
+
+	headers := mc.getHeaders()
+	require.Contains(t, headers.Get("user-agent")[0], customUserAgent)
+}

--- a/exporters/otlp/otlplogs/otlplogsgrpc/mock_collector_test.go
+++ b/exporters/otlp/otlplogs/otlplogsgrpc/mock_collector_test.go
@@ -1,0 +1,178 @@
+package otlplogsgrpc_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/otlplogstest"
+	"github.com/stretchr/testify/require"
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"net"
+	"sync"
+	"testing"
+)
+
+func makeMockCollector(t *testing.T, mockConfig *mockConfig) *mockCollector {
+	return &mockCollector{
+		t: t,
+		logsSvc: &mockLogsService{
+			storage: otlplogstest.NewLogsStorage(),
+			errors:  mockConfig.errors,
+			partial: mockConfig.partial,
+		},
+		stopped: make(chan struct{}),
+	}
+}
+
+type mockLogsService struct {
+	collectorlogspb.UnimplementedLogsServiceServer
+
+	errors      []error
+	partial     *collectorlogspb.ExportLogsPartialSuccess
+	requests    int
+	mu          sync.RWMutex
+	storage     otlplogstest.LogsStorage
+	headers     metadata.MD
+	exportBlock chan struct{}
+}
+
+func (mts *mockLogsService) getHeaders() metadata.MD {
+	mts.mu.RLock()
+	defer mts.mu.RUnlock()
+	return mts.headers
+}
+
+func (mts *mockLogsService) getLogs() []*logspb.LogRecord {
+	mts.mu.RLock()
+	defer mts.mu.RUnlock()
+	return mts.storage.GetLogRecords()
+}
+
+func (mts *mockLogsService) getResourceLogs() []*logspb.ResourceLogs {
+	mts.mu.RLock()
+	defer mts.mu.RUnlock()
+	return mts.storage.GetResourceLogs()
+}
+
+func (mts *mockLogsService) Export(ctx context.Context, exp *collectorlogspb.ExportLogsServiceRequest) (*collectorlogspb.ExportLogsServiceResponse, error) {
+	mts.mu.Lock()
+	defer func() {
+		mts.requests++
+		mts.mu.Unlock()
+	}()
+
+	if mts.exportBlock != nil {
+		// Do this with the lock held so the mockCollector.Stop does not
+		// abandon cleaning up resources.
+		<-mts.exportBlock
+	}
+
+	reply := &collectorlogspb.ExportLogsServiceResponse{
+		PartialSuccess: mts.partial,
+	}
+	if mts.requests < len(mts.errors) {
+		idx := mts.requests
+		return reply, mts.errors[idx]
+	}
+
+	mts.headers, _ = metadata.FromIncomingContext(ctx)
+	mts.storage.AddLogs(exp)
+	return reply, nil
+}
+
+type mockCollector struct {
+	t *testing.T
+
+	logsSvc *mockLogsService
+
+	endpoint string
+	stopFunc func()
+	stopOnce sync.Once
+	stopped  chan struct{}
+}
+
+type mockConfig struct {
+	errors   []error
+	endpoint string
+	partial  *collectorlogspb.ExportLogsPartialSuccess
+}
+
+var _ collectorlogspb.LogsServiceServer = (*mockLogsService)(nil)
+
+var errAlreadyStopped = fmt.Errorf("already stopped")
+
+func (mc *mockCollector) stop() error {
+	err := errAlreadyStopped
+	mc.stopOnce.Do(func() {
+		err = nil
+		if mc.stopFunc != nil {
+			mc.stopFunc()
+		}
+	})
+	// Wait until gRPC server is down.
+	<-mc.stopped
+
+	// Getting the lock ensures the logsSvc is done flushing.
+	mc.logsSvc.mu.Lock()
+	defer mc.logsSvc.mu.Unlock()
+
+	return err
+}
+
+func (mc *mockCollector) Stop() error {
+	return mc.stop()
+}
+
+func (mc *mockCollector) getLogRecords() []*logspb.LogRecord {
+	return mc.logsSvc.getLogs()
+}
+
+func (mc *mockCollector) getResourceLogs() []*logspb.ResourceLogs {
+	return mc.logsSvc.getResourceLogs()
+}
+
+func (mc *mockCollector) GetResourceLogs() []*logspb.ResourceLogs {
+	return mc.getResourceLogs()
+}
+
+func (mc *mockCollector) getHeaders() metadata.MD {
+	return mc.logsSvc.getHeaders()
+}
+
+// runMockCollector is a helper function to create a mock Collector.
+func runMockCollector(t *testing.T) *mockCollector {
+	t.Helper()
+	return runMockCollectorAtEndpoint(t, "localhost:0")
+}
+
+func runMockCollectorAtEndpoint(t *testing.T, endpoint string) *mockCollector {
+	t.Helper()
+	return runMockCollectorWithConfig(t, &mockConfig{endpoint: endpoint})
+}
+
+func runMockCollectorWithConfig(t *testing.T, mockConfig *mockConfig) *mockCollector {
+	t.Helper()
+	ln, err := net.Listen("tcp", mockConfig.endpoint)
+	require.NoError(t, err, "net.Listen")
+
+	srv := grpc.NewServer()
+	mc := makeMockCollector(t, mockConfig)
+	collectorlogspb.RegisterLogsServiceServer(srv, mc.logsSvc)
+	go func() {
+		_ = srv.Serve(ln)
+		close(mc.stopped)
+	}()
+
+	mc.endpoint = ln.Addr().String()
+	mc.stopFunc = srv.Stop
+
+	// Wait until gRPC server is up.
+	conn, err := grpc.Dial(mc.endpoint, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "grpc.Dial")
+	require.NoError(t, conn.Close(), "conn.Close")
+
+	return mc
+}

--- a/exporters/otlp/otlplogs/otlplogsgrpc/options.go
+++ b/exporters/otlp/otlplogs/otlplogsgrpc/options.go
@@ -41,7 +41,7 @@ func asGRPCOptions(opts []Option) []otlpconfig.GRPCOption {
 	return converted
 }
 
-// RetryConfig defines configuration for retrying export of span batches that
+// RetryConfig defines configuration for retrying export of logs batches that
 // failed to be received by the target endpoint.
 //
 // This configuration does not define any network retry strategy. That is
@@ -164,9 +164,9 @@ func WithGRPCConn(conn *grpc.ClientConn) Option {
 }
 
 // WithTimeout sets the max amount of time a client will attempt to export a
-// batch of spans. This takes precedence over any retry settings defined with
+// batch of logs. This takes precedence over any retry settings defined with
 // WithRetry, once this time limit has been reached the export is abandoned
-// and the batch of spans is dropped.
+// and the batch of logs is dropped.
 //
 // If unset, the default timeout will be set to 10 seconds.
 func WithTimeout(duration time.Duration) Option {
@@ -174,7 +174,7 @@ func WithTimeout(duration time.Duration) Option {
 }
 
 // WithRetry sets the retry policy for transient retryable errors that may be
-// returned by the target endpoint when exporting a batch of spans.
+// returned by the target endpoint when exporting a batch of logs.
 //
 // If the target endpoint responds with not only a retryable error, but
 // explicitly returns a backoff time in the response. That time will take

--- a/exporters/otlp/otlplogs/otlplogsgrpc/options.go
+++ b/exporters/otlp/otlplogs/otlplogsgrpc/options.go
@@ -1,0 +1,191 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlplogsgrpc
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/otlpconfig"
+	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/internal/retry"
+	"go.opentelemetry.io/otel"
+)
+
+// Option applies an option to the gRPC driver.
+type Option interface {
+	applyGRPCOption(otlpconfig.Config) otlpconfig.Config
+}
+
+func asGRPCOptions(opts []Option) []otlpconfig.GRPCOption {
+	converted := make([]otlpconfig.GRPCOption, len(opts))
+	for i, o := range opts {
+		converted[i] = otlpconfig.NewGRPCOption(o.applyGRPCOption)
+	}
+	return converted
+}
+
+// RetryConfig defines configuration for retrying export of span batches that
+// failed to be received by the target endpoint.
+//
+// This configuration does not define any network retry strategy. That is
+// entirely handled by the gRPC ClientConn.
+type RetryConfig retry.Config
+
+type wrappedOption struct {
+	otlpconfig.GRPCOption
+}
+
+func (w wrappedOption) applyGRPCOption(cfg otlpconfig.Config) otlpconfig.Config {
+	return w.ApplyGRPCOption(cfg)
+}
+
+// WithInsecure disables client transport security for the exporter's gRPC
+// connection just like grpc.WithInsecure()
+// (https://pkg.go.dev/google.golang.org/grpc#WithInsecure) does. Note, by
+// default, client security is required unless WithInsecure is used.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithInsecure() Option {
+	return wrappedOption{otlpconfig.WithInsecure()}
+}
+
+// WithEndpoint sets the target endpoint the exporter will connect to. If
+// unset, localhost:4317 will be used as a default.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithEndpoint(endpoint string) Option {
+	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}
+}
+
+// WithReconnectionPeriod set the minimum amount of time between connection
+// attempts to the target endpoint.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithReconnectionPeriod(rp time.Duration) Option {
+	return wrappedOption{otlpconfig.NewGRPCOption(func(cfg otlpconfig.Config) otlpconfig.Config {
+		cfg.ReconnectionPeriod = rp
+		return cfg
+	})}
+}
+
+func compressorToCompression(compressor string) otlpconfig.Compression {
+	if compressor == "gzip" {
+		return otlpconfig.GzipCompression
+	}
+
+	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression as default", compressor))
+	return otlpconfig.NoCompression
+}
+
+// WithCompressor sets the compressor for the gRPC client to use when sending
+// requests. It is the responsibility of the caller to ensure that the
+// compressor set has been registered with google.golang.org/grpc/encoding.
+// This can be done by encoding.RegisterCompressor. Some compressors
+// auto-register on import, such as gzip, which can be registered by calling
+// `import _ "google.golang.org/grpc/encoding/gzip"`.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithCompressor(compressor string) Option {
+	return wrappedOption{otlpconfig.WithCompression(compressorToCompression(compressor))}
+}
+
+// WithHeaders will send the provided headers with each gRPC requests.
+func WithHeaders(headers map[string]string) Option {
+	return wrappedOption{otlpconfig.WithHeaders(headers)}
+}
+
+// WithTLSCredentials allows the connection to use TLS credentials when
+// talking to the server. It takes in grpc.TransportCredentials instead of say
+// a Certificate file or a tls.Certificate, because the retrieving of these
+// credentials can be done in many ways e.g. plain file, in code tls.Config or
+// by certificate rotation, so it is up to the caller to decide what to use.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithTLSCredentials(creds credentials.TransportCredentials) Option {
+	return wrappedOption{otlpconfig.NewGRPCOption(func(cfg otlpconfig.Config) otlpconfig.Config {
+		cfg.Logs.GRPCCredentials = creds
+		return cfg
+	})}
+}
+
+// WithServiceConfig defines the default gRPC service config used.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithServiceConfig(serviceConfig string) Option {
+	return wrappedOption{otlpconfig.NewGRPCOption(func(cfg otlpconfig.Config) otlpconfig.Config {
+		cfg.ServiceConfig = serviceConfig
+		return cfg
+	})}
+}
+
+// WithDialOption sets explicit grpc.DialOptions to use when making a
+// connection. The options here are appended to the internal grpc.DialOptions
+// used so they will take precedence over any other internal grpc.DialOptions
+// they might conflict with.
+//
+// This option has no effect if WithGRPCConn is used.
+func WithDialOption(opts ...grpc.DialOption) Option {
+	return wrappedOption{otlpconfig.NewGRPCOption(func(cfg otlpconfig.Config) otlpconfig.Config {
+		cfg.DialOptions = opts
+		return cfg
+	})}
+}
+
+// WithGRPCConn sets conn as the gRPC ClientConn used for all communication.
+//
+// This option takes precedence over any other option that relates to
+// establishing or persisting a gRPC connection to a target endpoint. Any
+// other option of those types passed will be ignored.
+//
+// It is the callers responsibility to close the passed conn. The client
+// Shutdown method will not close this connection.
+func WithGRPCConn(conn *grpc.ClientConn) Option {
+	return wrappedOption{otlpconfig.NewGRPCOption(func(cfg otlpconfig.Config) otlpconfig.Config {
+		cfg.GRPCConn = conn
+		return cfg
+	})}
+}
+
+// WithTimeout sets the max amount of time a client will attempt to export a
+// batch of spans. This takes precedence over any retry settings defined with
+// WithRetry, once this time limit has been reached the export is abandoned
+// and the batch of spans is dropped.
+//
+// If unset, the default timeout will be set to 10 seconds.
+func WithTimeout(duration time.Duration) Option {
+	return wrappedOption{otlpconfig.WithTimeout(duration)}
+}
+
+// WithRetry sets the retry policy for transient retryable errors that may be
+// returned by the target endpoint when exporting a batch of spans.
+//
+// If the target endpoint responds with not only a retryable error, but
+// explicitly returns a backoff time in the response. That time will take
+// precedence over these settings.
+//
+// These settings do not define any network retry strategy. That is entirely
+// handled by the gRPC ClientConn.
+//
+// If unset, the default retry policy will be used. It will retry the export
+// 5 seconds after receiving a retryable error and increase exponentially
+// after each error for no more than a total time of 1 minute.
+func WithRetry(settings RetryConfig) Option {
+	return wrappedOption{otlpconfig.WithRetry(retry.Config(settings))}
+}

--- a/exporters/otlp/otlplogs/otlplogshttp/client.go
+++ b/exporters/otlp/otlplogs/otlplogshttp/client.go
@@ -76,7 +76,7 @@ type client struct {
 
 var _ otlplogs.Client = (*client)(nil)
 
-// NewClient creates a new HTTP trace client.
+// NewClient creates a new HTTP logs client.
 func NewClient(opts ...Option) otlplogs.Client {
 	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts)...)
 

--- a/exporters/otlp/otlplogs/otlplogshttp/example_test.go
+++ b/exporters/otlp/otlplogs/otlplogshttp/example_test.go
@@ -75,7 +75,7 @@ func installExportPipeline(ctx context.Context) (func(context.Context) error, er
 func Example() {
 	{
 		ctx := context.Background()
-		// Registers a tracer Provider globally.
+		// Registers a logger Provider globally.
 		shutdown, err := installExportPipeline(ctx)
 		if err != nil {
 			log.Fatal(err)

--- a/exporters/otlp/otlplogs/otlplogshttp/example_test.go
+++ b/exporters/otlp/otlplogs/otlplogshttp/example_test.go
@@ -25,19 +25,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"log"
+	"time"
 )
 
 const (
 	instrumentationName    = "github.com/instrumentron"
 	instrumentationVersion = "v0.1.0"
-)
-
-var (
-	logger = otel.GetLoggerProvider().Logger(
-		instrumentationName,
-		logs.WithInstrumentationVersion(instrumentationVersion),
-		logs.WithSchemaURL(semconv.SchemaURL),
-	)
 )
 
 func newResource() *resource.Resource {
@@ -49,9 +42,18 @@ func newResource() *resource.Resource {
 }
 
 func doSomething() {
+
+	logger := otel.GetLoggerProvider().Logger(
+		instrumentationName,
+		logs.WithInstrumentationVersion(instrumentationVersion),
+		logs.WithSchemaURL(semconv.SchemaURL),
+	)
+
 	body := "Body"
+	now := time.Now()
 	cfg := logs.LogRecordConfig{
-		Body: &body,
+		Timestamp: &now,
+		Body:      &body,
 	}
 	logRecord := logs.NewLogRecord(cfg)
 	logger.Emit(logRecord)
@@ -71,15 +73,19 @@ func installExportPipeline(ctx context.Context) (func(context.Context) error, er
 }
 
 func Example() {
-	ctx := context.Background()
-	// Registers a tracer Provider globally.
-	shutdown, err := installExportPipeline(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		if err := shutdown(ctx); err != nil {
+	{
+		ctx := context.Background()
+		// Registers a tracer Provider globally.
+		shutdown, err := installExportPipeline(ctx)
+		if err != nil {
 			log.Fatal(err)
 		}
-	}()
+		doSomething()
+
+		defer func() {
+			if err := shutdown(ctx); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
 }

--- a/exporters/otlp/otlplogs/otlplogshttp/options.go
+++ b/exporters/otlp/otlplogs/otlplogshttp/options.go
@@ -62,7 +62,7 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 }
 
 // WithEndpoint allows one to set the address of the collector
-// endpoint that the driver will use to send spans. If
+// endpoint that the driver will use to send logs. If
 // unset, it will instead try to use
 // the default endpoint (localhost:4318). Note that the endpoint
 // must not contain any URL path.
@@ -76,7 +76,7 @@ func WithCompression(compression Compression) Option {
 }
 
 // WithURLPath allows one to override the default URL path used
-// for sending traces. If unset, default ("/v1/traces") will be used.
+// for sending logs. If unset, default ("/v1/logs") will be used.
 func WithURLPath(urlPath string) Option {
 	return wrappedOption{otlpconfig.WithURLPath(urlPath)}
 }
@@ -102,13 +102,13 @@ func WithHeaders(headers map[string]string) Option {
 }
 
 // WithTimeout tells the driver the max waiting time for the backend to process
-// each spans batch.  If unset, the default will be 10 seconds.
+// each logs batch.  If unset, the default will be 10 seconds.
 func WithTimeout(duration time.Duration) Option {
 	return wrappedOption{otlpconfig.WithTimeout(duration)}
 }
 
 // WithRetry configures the retry policy for transient errors that may occurs
-// when exporting traces. An exponential back-off algorithm is used to ensure
+// when exporting logs. An exponential back-off algorithm is used to ensure
 // endpoints are not overwhelmed with retries. If unset, the default retry
 // policy will retry after 5 seconds and increase exponentially after each
 // error for a total of 1 minute.

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,11 @@ require (
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.opentelemetry.io/proto/otlp v0.19.0
+	go.uber.org/goleak v1.2.1
 	google.golang.org/grpc v1.55.0
 )
+
+require google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -23,7 +26,6 @@ require (
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
-	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLk
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/global/logs.go
+++ b/internal/global/logs.go
@@ -36,11 +36,11 @@ type loggerProvider struct {
 // interface.
 var _ logs.LoggerProvider = &loggerProvider{}
 
-// setDelegate configures p to delegate all TracerProvider functionality to
+// setDelegate configures p to delegate all LoggerProvider functionality to
 // provider.
 //
-// All Tracers provided prior to this function call are switched out to be
-// Tracers provided by provider.
+// All Loggers provided prior to this function call are switched out to be
+// Loggers provided by provider.
 //
 // It is guaranteed by the caller that this happens only once.
 func (p *loggerProvider) setDelegate(provider logs.LoggerProvider) {
@@ -69,7 +69,7 @@ func (p *loggerProvider) Logger(name string, opts ...logs.LoggerOption) logs.Log
 		return p.delegate.Logger(name, opts...)
 	}
 
-	// At this moment it is guaranteed that no sdk is installed, save the tracer in the tracers map.
+	// At this moment it is guaranteed that no sdk is installed, save the logger in the loggers map.
 
 	c := logs.NewLoggerConfig(opts...)
 	key := il{
@@ -117,7 +117,7 @@ func (t *logger) Emit(logRecord logs.LogRecord) {
 	}
 }
 
-// setDelegate configures t to delegate all Tracer functionality to Loggers
+// setDelegate configures t to delegate all Logger functionality to Loggers
 // created by provider.
 //
 // All subsequent calls to the Logger methods will be passed to the delegate.

--- a/logs/config.go
+++ b/logs/config.go
@@ -21,7 +21,7 @@ import "go.opentelemetry.io/otel/attribute"
 // LoggerConfig is a group of options for a Logger.
 type LoggerConfig struct {
 	instrumentationVersion string
-	// Schema URL of the telemetry emitted by the Tracer.
+	// Schema URL of the telemetry emitted by the Logger.
 	schemaURL string
 	attrs     attribute.Set
 }
@@ -37,7 +37,7 @@ func (t *LoggerConfig) InstrumentationAttributes() attribute.Set {
 	return t.attrs
 }
 
-// SchemaURL returns the Schema URL of the telemetry emitted by the Tracer.
+// SchemaURL returns the Schema URL of the telemetry emitted by the Logger.
 func (t *LoggerConfig) SchemaURL() string {
 	return t.schemaURL
 }

--- a/logs/doc.go
+++ b/logs/doc.go
@@ -48,7 +48,7 @@ a default.
 	)
 
 	type Instrumentation struct {
-		tracer logging.Logger
+		logger logging.Logger
 	}
 
 	func NewInstrumentation(tp logging.LoggerProvider) *Instrumentation {

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -40,8 +40,8 @@ type LogRecordConfig struct {
 	Attributes           *[]attribute.KeyValue
 }
 
-// NewLogRecord constructs a SpanContext using values from the provided
-// SpanContextConfig.
+// NewLogRecord constructs a LogRecord using values from the provided
+// LogRecordConfig.
 func NewLogRecord(config LogRecordConfig) LogRecord {
 	return LogRecord{
 		timestamp:            config.Timestamp,
@@ -147,9 +147,9 @@ type LoggerProvider interface {
 	// therefore, the WithInstrumentationVersion option should be used to
 	// distinguish these different codebases. Additionally, instrumentation
 	// libraries may sometimes use traces to communicate different domains of
-	// workflow data (i.e. using spans to communicate workflow events only). If
+	// workflow data (i.e. using logs to communicate workflow events only). If
 	// this is the case, the WithScopeAttributes option should be used to
-	// uniquely identify Tracers that handle the different domains of workflow
+	// uniquely identify Loggers that handle the different domains of workflow
 	// data.
 	//
 	// If the same name and options are passed multiple times, the same Logger

--- a/sdk/logs/batch_log_record_processor.go
+++ b/sdk/logs/batch_log_record_processor.go
@@ -40,24 +40,24 @@ type BatchLogRecordProcessorOption func(o *BatchLogRecordProcessorOptions)
 // BatchLogRecordProcessorOptions is configuration settings for a
 // BatchLogsProcessor.
 type BatchLogRecordProcessorOptions struct {
-	// MaxQueueSize is the maximum queue size to buffer spans for delayed processing. If the
-	// queue gets full it drops the spans. Use BlockOnQueueFull to change this behavior.
+	// MaxQueueSize is the maximum queue size to buffer logs for delayed processing. If the
+	// queue gets full it drops the logs. Use BlockOnQueueFull to change this behavior.
 	// The default value of MaxQueueSize is 2048.
 	MaxQueueSize int
 
 	// BatchTimeout is the maximum duration for constructing a batch. Processor
-	// forcefully sends available spans when timeout is reached.
+	// forcefully sends available logs when timeout is reached.
 	// The default value of BatchTimeout is 5000 msec.
 	BatchTimeout time.Duration
 
-	// ExportTimeout specifies the maximum duration for exporting spans. If the timeout
+	// ExportTimeout specifies the maximum duration for exporting logs. If the timeout
 	// is reached, the export will be cancelled.
 	// The default value of ExportTimeout is 30000 msec.
 	ExportTimeout time.Duration
 
-	// MaxExportBatchSize is the maximum number of spans to process in a single batch.
-	// If there are more than one batch worth of spans then it processes multiple batches
-	// of spans one batch after the other without any delay.
+	// MaxExportBatchSize is the maximum number of logs to process in a single batch.
+	// If there are more than one batch worth of logs then it processes multiple batches
+	// of logs one batch after the other without any delay.
 	// The default value of MaxExportBatchSize is 512.
 	MaxExportBatchSize int
 
@@ -157,7 +157,7 @@ func NewBatchLogRecordProcessor(exporter LogRecordExporter, options ...BatchLogR
 }
 
 func (lrp batchLogRecordProcessor) OnEmit(rol ReadableLogRecord) {
-	// Do not enqueue spans if we are just going to drop them.
+	// Do not enqueue logs if we are just going to drop them.
 	if lrp.e == nil {
 		return
 	}
@@ -277,7 +277,7 @@ func (lrp *batchLogRecordProcessor) enqueue(sd ReadableLogRecord) {
 	}
 }
 
-// ForceFlush exports all ended spans that have not yet been exported.
+// ForceFlush exports all ended logs that have not yet been exported.
 func (lrp *batchLogRecordProcessor) ForceFlush(ctx context.Context) error {
 	var err error
 	if lrp.e != nil {
@@ -363,12 +363,12 @@ func (lrp *batchLogRecordProcessor) enqueueDrop(ctx context.Context, ld Readable
 // MarshalLog is the marshaling function used by the logging system to represent this exporter.
 func (lrp *batchLogRecordProcessor) MarshalLog() interface{} {
 	return struct {
-		Type         string
-		SpanExporter LogRecordExporter
-		Config       BatchLogRecordProcessorOptions
+		Type              string
+		LogRecordExporter LogRecordExporter
+		Config            BatchLogRecordProcessorOptions
 	}{
-		Type:         "BatchLogRecordProcessor",
-		SpanExporter: lrp.e,
-		Config:       lrp.o,
+		Type:              "BatchLogRecordProcessor",
+		LogRecordExporter: lrp.e,
+		Config:            lrp.o,
 	}
 }

--- a/sdk/logs/batch_log_record_processor.go
+++ b/sdk/logs/batch_log_record_processor.go
@@ -68,6 +68,49 @@ type BatchLogRecordProcessorOptions struct {
 	BlockOnQueueFull bool
 }
 
+// WithMaxQueueSize returns a BatchLogRecordProcessorOption that configures the
+// maximum queue size allowed for a BatchLogRecordProcessor.
+func WithMaxQueueSize(size int) BatchLogRecordProcessorOption {
+	return func(o *BatchLogRecordProcessorOptions) {
+		o.MaxQueueSize = size
+	}
+}
+
+// WithMaxExportBatchSize returns a BatchLogRecordProcessorOption that configures
+// the maximum export batch size allowed for a BatchLogRecordProcessor.
+func WithMaxExportBatchSize(size int) BatchLogRecordProcessorOption {
+	return func(o *BatchLogRecordProcessorOptions) {
+		o.MaxExportBatchSize = size
+	}
+}
+
+// WithBatchTimeout returns a BatchLogRecordProcessorOption that configures the
+// maximum delay allowed for a BatchLogRecordProcessor before it will export any
+// held log (whether the queue is full or not).
+func WithBatchTimeout(delay time.Duration) BatchLogRecordProcessorOption {
+	return func(o *BatchLogRecordProcessorOptions) {
+		o.BatchTimeout = delay
+	}
+}
+
+// WithExportTimeout returns a BatchLogRecordProcessorOption that configures the
+// amount of time a BatchLogRecordProcessor waits for an exporter to export before
+// abandoning the export.
+func WithExportTimeout(timeout time.Duration) BatchLogRecordProcessorOption {
+	return func(o *BatchLogRecordProcessorOptions) {
+		o.ExportTimeout = timeout
+	}
+}
+
+// WithBlocking returns a BatchLogRecordProcessorOption that configures a
+// BatchLogRecordProcessor to wait for enqueue operations to succeed instead of
+// dropping data when the queue is full.
+func WithBlocking() BatchLogRecordProcessorOption {
+	return func(o *BatchLogRecordProcessorOptions) {
+		o.BlockOnQueueFull = true
+	}
+}
+
 // batchLogRecordProcessor is a LogRecordProcessor that batches asynchronously-received
 // logs and sends them to a logs.Exporter when complete.
 type batchLogRecordProcessor struct {

--- a/sdk/logs/log_record_exporter.go
+++ b/sdk/logs/log_record_exporter.go
@@ -27,7 +27,7 @@ type LogRecordExporter interface {
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.
 
-	// Export exports a batch of spans.
+	// Export exports a batch of logs.
 	//
 	// This function is called synchronously, so there is no concurrency
 	// safety requirement. However, due to the synchronous calling pattern,

--- a/sdk/logs/log_record_processor.go
+++ b/sdk/logs/log_record_processor.go
@@ -49,7 +49,7 @@ type LogRecordProcessor interface {
 	// ForceFlush exports all ended logs to the configured Exporter that have not yet
 	// been exported.  It should only be called when absolutely necessary, such as when
 	// using a FaaS provider that may suspend the process after an invocation, but before
-	// the Processor can export the completed spans.
+	// the Processor can export the completed logs.
 	ForceFlush(ctx context.Context) error
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.

--- a/sdk/logs/logs_test.go
+++ b/sdk/logs/logs_test.go
@@ -1,0 +1,32 @@
+package logs
+
+import (
+	"context"
+	"sync"
+)
+
+type testExporter struct {
+	mu   sync.RWMutex
+	idx  map[string]int
+	logs []*ReadableLogRecord
+}
+
+func NewTestExporter() *testExporter {
+	return &testExporter{idx: make(map[string]int)}
+}
+
+func (te *testExporter) Export(ctx context.Context, logs []ReadableLogRecord) error {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+
+	i := len(te.logs)
+	for _, s := range logs {
+		te.logs = append(te.logs, &s)
+		i++
+	}
+	return nil
+}
+
+func (te *testExporter) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/sdk/logs/logstest/log_record.go
+++ b/sdk/logs/logstest/log_record.go
@@ -1,0 +1,109 @@
+package logstest
+
+import (
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	logssdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
+	"time"
+)
+
+// LogRecordStubs is a slice of LogRecordStub use for testing an SDK.
+type LogRecordStubs []LogRecordStub
+
+// Snapshots returns s as a slice of ReadOnlySpans.
+func (l LogRecordStubs) Snapshots() []logssdk.ReadableLogRecord {
+	if len(l) == 0 {
+		return nil
+	}
+
+	rlr := make([]logssdk.ReadableLogRecord, len(l))
+	for i := 0; i < len(l); i++ {
+		rlr[i] = l[i].Snapshot()
+	}
+	return rlr
+}
+
+// LogRecordStub is a stand-in for a LogRecord.
+type LogRecordStub struct {
+	Timestamp            *time.Time
+	ObservedTimestamp    time.Time
+	TraceId              *trace.TraceID
+	SpanId               *trace.SpanID
+	TraceFlags           *trace.TraceFlags
+	SeverityText         *string
+	SeverityNumber       *logs.SeverityNumber
+	Body                 *string
+	Resource             *resource.Resource
+	InstrumentationScope *instrumentation.Scope
+	Attributes           *[]attribute.KeyValue
+}
+
+// LogRecordStubFromReadableLogRecord returns a LogRecordStub populated from rl.
+func LogRecordStubFromReadableLogRecord(rl logssdk.ReadableLogRecord) LogRecordStub {
+	if rl == nil {
+		return LogRecordStub{}
+	}
+	return LogRecordStub{
+		Timestamp:            rl.Timestamp(),
+		ObservedTimestamp:    rl.ObservedTimestamp(),
+		TraceId:              rl.TraceId(),
+		SpanId:               rl.SpanId(),
+		TraceFlags:           rl.TraceFlags(),
+		SeverityText:         rl.SeverityText(),
+		SeverityNumber:       rl.SeverityNumber(),
+		Body:                 rl.Body(),
+		Resource:             rl.Resource(),
+		InstrumentationScope: rl.InstrumentationScope(),
+		Attributes:           rl.Attributes(),
+	}
+}
+
+// Snapshot returns a read-only copy of the SpanStub.
+func (s LogRecordStub) Snapshot() logssdk.ReadableLogRecord {
+	return &logRecordSnapshot{
+		timestamp:            s.Timestamp,
+		observedTimestamp:    s.ObservedTimestamp,
+		traceId:              s.TraceId,
+		spanId:               s.SpanId,
+		traceFlags:           s.TraceFlags,
+		severityText:         s.SeverityText,
+		severityNumber:       s.SeverityNumber,
+		body:                 s.Body,
+		resource:             s.Resource,
+		instrumentationScope: s.InstrumentationScope,
+		attributes:           s.Attributes,
+	}
+}
+
+type logRecordSnapshot struct {
+	// Embed the interface to implement the private method.
+	logssdk.ReadableLogRecord
+	timestamp            *time.Time
+	observedTimestamp    time.Time
+	traceId              *trace.TraceID
+	spanId               *trace.SpanID
+	traceFlags           *trace.TraceFlags
+	severityText         *string
+	severityNumber       *logs.SeverityNumber
+	body                 *string
+	resource             *resource.Resource
+	instrumentationScope *instrumentation.Scope
+	attributes           *[]attribute.KeyValue
+}
+
+func (r *logRecordSnapshot) Timestamp() *time.Time         { return r.timestamp }
+func (r *logRecordSnapshot) ObservedTimestamp() time.Time  { return r.observedTimestamp }
+func (r *logRecordSnapshot) TraceId() *trace.TraceID       { return r.traceId }
+func (r *logRecordSnapshot) SpanId() *trace.SpanID         { return r.spanId }
+func (r *logRecordSnapshot) TraceFlags() *trace.TraceFlags { return r.traceFlags }
+func (r *logRecordSnapshot) InstrumentationScope() *instrumentation.Scope {
+	return r.instrumentationScope
+}
+func (r *logRecordSnapshot) SeverityText() *string                { return r.severityText }
+func (r *logRecordSnapshot) SeverityNumber() *logs.SeverityNumber { return r.severityNumber }
+func (r *logRecordSnapshot) Body() *string                        { return r.body }
+func (r *logRecordSnapshot) Resource() *resource.Resource         { return r.resource }
+func (r *logRecordSnapshot) Attributes() *[]attribute.KeyValue    { return r.attributes }

--- a/sdk/logs/logstest/log_record.go
+++ b/sdk/logs/logstest/log_record.go
@@ -13,7 +13,7 @@ import (
 // LogRecordStubs is a slice of LogRecordStub use for testing an SDK.
 type LogRecordStubs []LogRecordStub
 
-// Snapshots returns s as a slice of ReadOnlySpans.
+// Snapshots returns s as a slice of ReadableLogRecords.
 func (l LogRecordStubs) Snapshots() []logssdk.ReadableLogRecord {
 	if len(l) == 0 {
 		return nil
@@ -61,7 +61,7 @@ func LogRecordStubFromReadableLogRecord(rl logssdk.ReadableLogRecord) LogRecordS
 	}
 }
 
-// Snapshot returns a read-only copy of the SpanStub.
+// Snapshot returns a read-only copy of the LogRecordStub.
 func (s LogRecordStub) Snapshot() logssdk.ReadableLogRecord {
 	return &logRecordSnapshot{
 		timestamp:            s.Timestamp,

--- a/sdk/logs/provider.go
+++ b/sdk/logs/provider.go
@@ -160,13 +160,13 @@ var _ logs.LoggerProvider = &LoggerProvider{}
 func NewLoggerProvider(opts ...LoggerProviderOption) *LoggerProvider {
 	o := loggerProviderConfig{}
 
-	// TODO: o = applyLoggerProviderEnvConfigs(o)
+	o = applyLoggerProviderEnvConfigs(o)
 
 	for _, opt := range opts {
 		o = opt.apply(o)
 	}
 
-	// TODO: o = ensureValidLoggerProviderConfig(o)
+	o = ensureValidLoggerProviderConfig(o)
 
 	lp := &LoggerProvider{
 		namedLogger: make(map[instrumentation.Scope]*logger),
@@ -184,17 +184,6 @@ func NewLoggerProvider(opts ...LoggerProviderOption) *LoggerProvider {
 	return lp
 
 }
-
-//func (lp LoggerProvider) Send(rol ReadWriteLogRecord) {
-//
-//	// add resource level attributes
-//	rol.SetResource(lp.cfg.resource)
-//
-//	// process log
-//	for _, p := range lp.cfg.processors {
-//		p.OnEmit(rol)
-//	}
-//}
 
 func (p *LoggerProvider) getLogsProcessors() logRecordProcessorStates {
 	return *(p.logProcessors.Load())
@@ -258,4 +247,27 @@ func (p *LoggerProvider) ForceFlush(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func applyLoggerProviderEnvConfigs(cfg loggerProviderConfig) loggerProviderConfig {
+	for _, opt := range loggerProviderOptionsFromEnv() {
+		cfg = opt.apply(cfg)
+	}
+
+	return cfg
+}
+
+func loggerProviderOptionsFromEnv() []LoggerProviderOption {
+	var opts []LoggerProviderOption
+
+	return opts
+}
+
+// ensureValidLoggerProviderConfig ensures that given LoggerProviderConfig is valid.
+func ensureValidLoggerProviderConfig(cfg loggerProviderConfig) loggerProviderConfig {
+
+	if cfg.resource == nil {
+		cfg.resource = resource.Default()
+	}
+	return cfg
 }

--- a/sdk/logs/provider.go
+++ b/sdk/logs/provider.go
@@ -69,8 +69,8 @@ func WithSyncer(e LogRecordExporter) LoggerProviderOption {
 	return WithLogRecordProcessor(NewSimpleLogRecordProcessor(e))
 }
 
-// WithBatcher registers the exporter with the TracerProvider using a
-// BatchSpanProcessor configured with the passed opts.
+// WithBatcher registers the exporter with the LoggerProvider using a
+// BatchLogRecordProcessor configured with the passed opts.
 func WithBatcher(e LogRecordExporter, opts ...BatchLogRecordProcessorOption) LoggerProviderOption {
 	return WithLogRecordProcessor(NewBatchLogRecordProcessor(e, opts...))
 }
@@ -228,7 +228,7 @@ func (p LoggerProvider) Shutdown(ctx context.Context) error {
 }
 
 // ForceFlush immediately exports all logs that have not yet been exported for
-// all the registered span processors.
+// all the registered log processors.
 func (p *LoggerProvider) ForceFlush(ctx context.Context) error {
 	spss := p.getLogsProcessors()
 	if len(spss) == 0 {

--- a/sdk/logs/provider_test.go
+++ b/sdk/logs/provider_test.go
@@ -17,8 +17,7 @@ limitations under the License.
 package logs
 
 import (
-	"context"
-	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogshttp"
+	//	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogshttp"
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
@@ -39,10 +38,10 @@ func TestLogsProvider(t *testing.T) {
 		logs.WithSchemaURL(semconv.SchemaURL),
 	)
 
-	logsOtlpExporter, _ := otlplogshttp.New(context.Background())
+	logRecordExporter := NewTestExporter()
 
 	batchOtlpLogger := NewLoggerProvider(
-		WithLogRecordProcessor(NewBatchLogRecordProcessor(logsOtlpExporter)),
+		WithLogRecordProcessor(NewBatchLogRecordProcessor(logRecordExporter)),
 		WithResource(
 			resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceName("unit_test"))),
 	).Logger("otlp",

--- a/sdk/logs/simple_log_record_processor.go
+++ b/sdk/logs/simple_log_record_processor.go
@@ -51,7 +51,7 @@ func NewSimpleLogRecordProcessor(exporter LogRecordExporter) LogRecordProcessor 
 	slp := &simpleLogRecordProcessor{
 		exporter: exporter,
 	}
-	log.Printf("SimpleLogsProcessor is not recommended for production use, consider using BatchSpanProcessor instead.")
+	log.Printf("SimpleLogsProcessor is not recommended for production use, consider using BatchLogRecordProcessor instead.")
 
 	return slp
 }


### PR DESCRIPTION
This PR will add `otlpgrpc` exporter 

```go
import (
	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogsgrpc"
	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
)


client := otlplogsgrpc.NewClient()
exporter, _ := otlplogs.New(ctx, client)
```
