### PR TITLE
stdout exporter

### DIFF
--- a/exporters/stdout/stdoutlogs/config.go
+++ b/exporters/stdout/stdoutlogs/config.go
@@ -1,0 +1,62 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stdoutlogs
+
+import (
+	"io"
+	"os"
+)
+
+var (
+	defaultWriter = os.Stdout
+)
+
+// config contains options for the STDOUT exporter.
+type config struct {
+	// Writer is the destination.  If not set, os.Stdout is used.
+	Writer io.Writer
+}
+
+// newConfig creates a validated Config configured with options.
+func newConfig(options ...Option) (config, error) {
+	cfg := config{
+		Writer: defaultWriter,
+	}
+	for _, opt := range options {
+		cfg = opt.apply(cfg)
+	}
+	return cfg, nil
+}
+
+// Option sets the value of an option for a Config.
+type Option interface {
+	apply(config) config
+}
+
+// WithWriter sets the export stream destination.
+func WithWriter(w io.Writer) Option {
+	return writerOption{w}
+}
+
+type writerOption struct {
+	W io.Writer
+}
+
+func (o writerOption) apply(cfg config) config {
+	cfg.Writer = o.W
+	return cfg
+}

--- a/exporters/stdout/stdoutlogs/doc.go
+++ b/exporters/stdout/stdoutlogs/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stdoutlogs

--- a/exporters/stdout/stdoutlogs/example_test.go
+++ b/exporters/stdout/stdoutlogs/example_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stdoutlogs
+
+import (
+	"context"
+	"github.com/agoda-com/opentelemetry-logs-go"
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"log"
+	"time"
+)
+
+const (
+	instrumentationName    = "github.com/instrumentron"
+	instrumentationVersion = "v0.1.0"
+)
+
+func newResource() *resource.Resource {
+	return resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("otlplogs-example"),
+		semconv.ServiceVersion("0.0.1"),
+	)
+}
+
+func doSomething() {
+
+	logger := otel.GetLoggerProvider().Logger(
+		instrumentationName,
+		logs.WithInstrumentationVersion(instrumentationVersion),
+		logs.WithSchemaURL(semconv.SchemaURL),
+	)
+
+	body := "My message"
+	now := time.Now()
+	sn := logs.INFO
+	cfg := logs.LogRecordConfig{
+		Timestamp:         &now,
+		ObservedTimestamp: now,
+		Body:              &body,
+		SeverityNumber:    &sn,
+	}
+	logRecord := logs.NewLogRecord(cfg)
+	logger.Emit(logRecord)
+}
+
+func installExportPipeline(ctx context.Context) (func(context.Context) error, error) {
+	exporter, _ := New()
+
+	loggerProvider := sdk.NewLoggerProvider(
+		sdk.WithSyncer(exporter),
+		sdk.WithResource(newResource()),
+	)
+	otel.SetLoggerProvider(loggerProvider)
+
+	return loggerProvider.Shutdown, nil
+}
+
+func Example() {
+	{
+		ctx := context.Background()
+		// Registers a logger Provider globally.
+		shutdown, err := installExportPipeline(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		doSomething()
+
+		defer func() {
+			if err := shutdown(ctx); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
+}

--- a/exporters/stdout/stdoutlogs/exporter.go
+++ b/exporters/stdout/stdoutlogs/exporter.go
@@ -1,0 +1,161 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stdoutlogs
+
+import (
+	"context"
+	"fmt"
+	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+var _ sdk.LogRecordExporter = &Exporter{}
+
+// New creates an Exporter with the passed options.
+func New(options ...Option) (*Exporter, error) {
+	cfg, err := newConfig(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Exporter{
+		writer: cfg.Writer,
+	}, nil
+}
+
+// Exporter is an implementation of logs.LogRecordSyncer that writes spans to stdout.
+type Exporter struct {
+	writer    io.Writer
+	encoderMu sync.Mutex
+
+	stoppedMu sync.RWMutex
+	stopped   bool
+}
+
+// Export writes logs in json format to stdout.
+func (e *Exporter) Export(ctx context.Context, logs []sdk.ReadableLogRecord) error {
+	e.stoppedMu.RLock()
+	stopped := e.stopped
+	e.stoppedMu.RUnlock()
+	if stopped {
+		return nil
+	}
+
+	if len(logs) == 0 {
+		return nil
+	}
+
+	wr := os.Stdout
+
+	logRecords := logRecordsFromReadableLogRecords(logs)
+
+	e.encoderMu.Lock()
+	defer e.encoderMu.Unlock()
+	for _, lr := range logRecords {
+
+		var logMessageBuilder strings.Builder
+
+		logMessageBuilder.WriteString(lr.ObservedTimestamp.Format(time.RFC3339))
+		logMessageBuilder.WriteString(" ")
+		logMessageBuilder.WriteString(lr.getSeverityText())
+		logMessageBuilder.WriteString(" ")
+		if lr.Body != nil {
+			logMessageBuilder.WriteString(*lr.Body)
+			logMessageBuilder.WriteString(" ")
+		}
+
+		if lr.TraceId != nil || lr.SpanId != nil {
+			logMessageBuilder.WriteString(": ")
+			if lr.TraceId != nil {
+				traceId := *lr.TraceId
+				logMessageBuilder.WriteString("traceId=")
+				logMessageBuilder.WriteString(traceId.String())
+				logMessageBuilder.WriteString(" ")
+			}
+			if lr.SpanId != nil {
+				spanId := *lr.SpanId
+				logMessageBuilder.WriteString("spanId=")
+				logMessageBuilder.WriteString(spanId.String())
+				logMessageBuilder.WriteString(" ")
+			}
+		}
+
+		if lr.InstrumentationScope != nil {
+			logMessageBuilder.WriteString("[scopeInfo: ")
+			scope := *lr.InstrumentationScope
+			logMessageBuilder.WriteString(scope.Name)
+			if scope.Version != "" {
+				logMessageBuilder.WriteString(":")
+				logMessageBuilder.WriteString(scope.Version)
+			}
+			logMessageBuilder.WriteString("] ")
+		}
+
+		attributes := lr.Resource.Attributes()
+		if lr.Attributes != nil {
+			attributes = append(attributes, *lr.Attributes...)
+		}
+
+		if len(attributes) > 0 {
+			logMessageBuilder.WriteString("{")
+			for i, a := range attributes {
+				logMessageBuilder.WriteString(string(a.Key))
+				logMessageBuilder.WriteString("=")
+				logMessageBuilder.WriteString(a.Value.AsString())
+				if i < len(attributes)-1 {
+					logMessageBuilder.WriteString(", ")
+				}
+			}
+			logMessageBuilder.WriteString("}")
+		}
+
+		// Print logRecords, one by one
+		_, err := fmt.Fprintf(wr, "%s\n", logMessageBuilder.String())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Shutdown is called to stop the exporter, it performs no action.
+func (e *Exporter) Shutdown(ctx context.Context) error {
+	e.stoppedMu.Lock()
+	e.stopped = true
+	e.stoppedMu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return nil
+}
+
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (e *Exporter) MarshalLog() interface{} {
+	return struct {
+		Type           string
+		WithTimestamps bool
+	}{
+		Type: "stdout",
+	}
+}

--- a/exporters/stdout/stdoutlogs/stdout_record.go
+++ b/exporters/stdout/stdoutlogs/stdout_record.go
@@ -1,0 +1,92 @@
+/*
+Copyright Agoda Services Co.,Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stdoutlogs
+
+import (
+	"github.com/agoda-com/opentelemetry-logs-go/logs"
+	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
+	"time"
+)
+
+// stdOutLogRecord is a stand-in for a LogRecord.
+type stdOutLogRecord struct {
+	Timestamp            *time.Time
+	ObservedTimestamp    time.Time
+	TraceId              *trace.TraceID
+	SpanId               *trace.SpanID
+	TraceFlags           *trace.TraceFlags
+	SeverityText         *string
+	SeverityNumber       *logs.SeverityNumber
+	Body                 *string
+	Resource             *resource.Resource
+	InstrumentationScope *instrumentation.Scope
+	Attributes           *[]attribute.KeyValue
+}
+
+func (lr stdOutLogRecord) getSeverityText() string {
+	if lr.SeverityNumber == nil {
+		return "UNSPECIFIED"
+	} else {
+		sn := int32(*lr.SeverityNumber)
+		if sn >= 1 && sn <= 4 {
+			return "TRACE"
+		}
+		if sn >= 5 && sn <= 8 {
+			return "DEBUG"
+		}
+		if sn >= 9 && sn <= 12 {
+			return "INFO"
+		}
+		if sn >= 13 && sn <= 16 {
+			return "WARN"
+		}
+		if sn >= 17 && sn <= 20 {
+			return "ERROR"
+		}
+		if sn >= 21 && sn <= 24 {
+			return "FATAL"
+		}
+		return "UNSPECIFIED"
+	}
+}
+
+func logRecordsFromReadableLogRecords(logRecords []sdk.ReadableLogRecord) []stdOutLogRecord {
+
+	var result []stdOutLogRecord
+
+	for _, lr := range logRecords {
+		logRecord := stdOutLogRecord{
+			Timestamp:            lr.Timestamp(),
+			ObservedTimestamp:    lr.ObservedTimestamp(),
+			TraceId:              lr.TraceId(),
+			SpanId:               lr.SpanId(),
+			TraceFlags:           lr.TraceFlags(),
+			SeverityText:         lr.SeverityText(),
+			SeverityNumber:       lr.SeverityNumber(),
+			Body:                 lr.Body(),
+			Resource:             lr.Resource(),
+			InstrumentationScope: lr.InstrumentationScope(),
+			Attributes:           lr.Attributes(),
+		}
+		result = append(result, logRecord)
+	}
+	return result
+}


### PR DESCRIPTION
This PR will add stdout exporter minimal functionality

```golang
import (
  stdout "github.com/agoda-com/opentelemetry-logs-go/exporters/stdout/stdoutlogs"
  sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
)

exporter, _ := stdout.New()

loggerProvider := sdk.NewLoggerProvider(
	sdk.WithSyncer(exporter),
)
```

Example of log:

```
2023-07-31T12:27:09+07:00 INFO My message {service.name=otlplogs-example, service.version=0.0.1}
```