### PR TITLE
release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.2.0] 2023-08-30
+
 ### Changed
 
 - opentelemetry update to 1.17.0


### PR DESCRIPTION
## [v0.2.0] 2023-08-30

### Changed

- opentelemetry update to 1.17.0
- `github.com/golang/protobuf/proto` replaced with `google.golang.org/protobuf`
- `otlp/internal` package moved to `otlp/otlplogs/internal`
- more unit tests added