### PR TITLE
release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.3.0] 2023-09-13
+
 ### Changed
 
 - opentelemetry update to 1.18.0
 
 ### Fixed
+
 - stdoutlogs writer parameter was ignored
 
 ## [v0.2.0] 2023-08-30
@@ -39,16 +42,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `http/json` protocol supported in otlplogshttp exporter
 - `stdout` logs logger
 - Package split into separate `otel`, `sdk`, `exporters/otlp/otlplogs` and `exporters/stdout/stdoutlogs` packages
-- `OTEL_EXPORTER_OTLP_PROTOCOL` env variable to configure `grpc`, `http/protobuf` and `http/json` otlp formats with OTEL logs exporter
-- `autoconfigure` sdk package with `OTEL_LOGS_EXPORTER` env variable support with `none`,`otlp` and `logging` options to autoconfigure logger provider
+- `OTEL_EXPORTER_OTLP_PROTOCOL` env variable to configure `grpc`, `http/protobuf` and `http/json` otlp formats with OTEL
+  logs exporter
+- `autoconfigure` sdk package with `OTEL_LOGS_EXPORTER` env variable support with `none`,`otlp` and `logging` options to
+  autoconfigure logger provider
 
 ## [v0.0.1] 2023-07-25
 
 ### Added
 
-- implementation of [Logs Bridge API](https://opentelemetry.io/docs/specs/otel/logs/bridge-api) with Stable API and SDK API interfaces.
+- implementation of [Logs Bridge API](https://opentelemetry.io/docs/specs/otel/logs/bridge-api) with Stable API and SDK
+  API interfaces.
 - Package all-in-one for logs `github.com/agoda-com/opentelemetry-logs-go`
-- Package module `semconv` with [Logs Exceptions Semantic Conventions](https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/exceptions/#attributes)
-- Package module `logs` with [Stable Log Model](https://opentelemetry.io/docs/specs/otel/logs/data-model), [Logger](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#logger) and [LoggerProvider](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#loggerprovider) interfaces
+- Package module `semconv`
+  with [Logs Exceptions Semantic Conventions](https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/exceptions/#attributes)
+- Package module `logs`
+  with [Stable Log Model](https://opentelemetry.io/docs/specs/otel/logs/data-model), [Logger](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#logger)
+  and [LoggerProvider](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#loggerprovider) interfaces
 - Package module `sdk` with [Logger SDK](https://opentelemetry.io/docs/specs/otel/logs/sdk/) implementation
-- Package module `exporters` with [Built-in processors](https://opentelemetry.io/docs/specs/otel/logs/sdk/#built-in-processors), `otlp` interface  and `noop` and `http/protobuf` exporters
+- Package module `exporters`
+  with [Built-in processors](https://opentelemetry.io/docs/specs/otel/logs/sdk/#built-in-processors), `otlp` interface
+  and `noop` and `http/protobuf` exporters


### PR DESCRIPTION
## [v0.3.0] 2023-09-13

### Changed

- opentelemetry updated to 1.18.0

### Fixed

- stdoutlogs writer parameter was ignored