### PR TITLE
release/v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.4.0] 2023-10-02
 
 ### Changed
 


### PR DESCRIPTION
### Changed

- opentelemetry updated to 1.19.0
- drop compatibility guarantee of Go [1.19](https://go.dev/doc/go1.19)
