### PR TITLE
bug: merge the logRecord resources with those provided by the logProvider

### DIFF
--- a/sdk/logs/logger.go
+++ b/sdk/logs/logger.go
@@ -40,7 +40,10 @@ func (l logger) Emit(logRecord logs.LogRecord) {
 		return
 	}
 
-	pr := l.provider.resource
+	pr, err := resource.Merge(l.provider.resource, logRecord.Resource())
+	if err != nil {
+		return
+	}
 
 	elr := &exportableLogRecord{
 		timestamp:            logRecord.Timestamp(),


### PR DESCRIPTION
This PR enables customizing the resource attributes for any emitted logRecord.

In our specific use case, our [monitoring agent ](https://github.com/coroot/coroot-node-agent) collects logs of every container running on a node and subsequently sends these logs to the OpenTelemetry collector. Therefore, we need to set the `container.id` and `service.name` resource attributes for each log entry emitted.

