### PR TITLE
release/v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v0.5.0] 2024-04-21
 
 ### Changed
 
 - opentelemetry updated to 1.25.0
-- minimal go version 1.21
+
+### Removed 
+
+- Drop support for [Go 1.20](https://go.dev/doc/go1.20)
 
 ## [v0.4.3] 2023-11-02
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ package myInstrumentedLogger
 import (
 	otel "github.com/agoda-com/opentelemetry-logs-go"
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
 const (
@@ -86,7 +86,7 @@ import (
 	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs"
 	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogshttp"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
 )
 

--- a/autoconfigure/README.md
+++ b/autoconfigure/README.md
@@ -19,7 +19,7 @@ import (
 	"os"
 	"context"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	autosdk "github.com/agoda-com/opentelemetry-logs-go/autoconfigure/sdk/logs"
 )
 

--- a/autoconfigure/sdk/logs/provider_test.go
+++ b/autoconfigure/sdk/logs/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
 	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
 	"github.com/stretchr/testify/assert"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"testing"
 	"time"
 )

--- a/exporters/otlp/otlplogs/clients_http_example_test.go
+++ b/exporters/otlp/otlplogs/clients_http_example_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
 	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"log"
 	"time"
 )

--- a/exporters/stdout/stdoutlogs/exporter_test.go
+++ b/exporters/stdout/stdoutlogs/exporter_test.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"io"
 	"log"
 	"testing"

--- a/sdk/logs/logger_test.go
+++ b/sdk/logs/logger_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 	"testing"
 	"time"

--- a/sdk/logs/provider_test.go
+++ b/sdk/logs/provider_test.go
@@ -20,7 +20,7 @@ import (
 	//	"github.com/agoda-com/opentelemetry-logs-go/exporters/otlp/otlplogs/otlplogshttp"
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"testing"
 )
 


### PR DESCRIPTION
### Changed

- opentelemetry updated to 1.25.0

### Removed 

- Drop support for [Go 1.20](https://go.dev/doc/go1.20)
