### PR TITLE
fix: make LogRecord accept the "any" type as Body

### DIFF
--- a/exporters/otlp/otlplogs/internal/logstransform/logs.go
+++ b/exporters/otlp/otlplogs/internal/logstransform/logs.go
@@ -21,6 +21,10 @@ import (
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -65,15 +69,6 @@ func Logs(sdl []sdk.ReadableLogRecord) []*logspb.ResourceLogs {
 }
 
 func logRecord(record sdk.ReadableLogRecord) *logspb.LogRecord {
-	var body *commonpb.AnyValue = nil
-	if record.Body() != nil {
-		body = &commonpb.AnyValue{
-			Value: &commonpb.AnyValue_StringValue{
-				StringValue: *record.Body(),
-			},
-		}
-	}
-
 	var traceIDBytes []byte
 	if record.TraceId() != nil {
 		tid := *record.TraceId()
@@ -114,13 +109,203 @@ func logRecord(record sdk.ReadableLogRecord) *logspb.LogRecord {
 	logRecord := &logspb.LogRecord{
 		TimeUnixNano:         uint64(ts.UnixNano()),
 		ObservedTimeUnixNano: uint64(record.ObservedTimestamp().UnixNano()),
-		TraceId:              traceIDBytes,       // provide the associated trace ID if available
-		SpanId:               spanIDBytes,        // provide the associated span ID if available
-		Flags:                uint32(traceFlags), // provide the associated trace flags
-		Body:                 body,               // provide the associated log body if available
-		Attributes:           kv,                 // provide additional log attributes if available
+		TraceId:              traceIDBytes,                   // provide the associated trace ID if available
+		SpanId:               spanIDBytes,                    // provide the associated span ID if available
+		Flags:                uint32(traceFlags),             // provide the associated trace flags
+		Body:                 valueToAnyValue(record.Body()), // provide the associated log body if available
+		Attributes:           kv,                             // provide additional log attributes if available
 		SeverityText:         st,
 		SeverityNumber:       sn,
 	}
 	return logRecord
+}
+
+func valueToAnyValue(value any) *commonpb.AnyValue {
+	if value == nil {
+		return nil
+	}
+	typ := reflect.TypeOf(value)
+	val := reflect.ValueOf(value)
+	if valueIsNil(typ, val) {
+		return nil
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	}
+	switch {
+	case val.CanFloat():
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_DoubleValue{
+				DoubleValue: val.Float(),
+			},
+		}
+	case val.CanInt():
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_IntValue{
+				IntValue: val.Int(),
+			},
+		}
+	case val.Kind() == reflect.Bool:
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_BoolValue{
+				BoolValue: val.Bool(),
+			},
+		}
+	case val.CanUint():
+		valUInt := val.Uint()
+		if valUInt > math.MaxInt64 {
+			valUInt = math.MaxInt64
+		}
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_IntValue{
+				IntValue: int64(valUInt),
+			},
+		}
+	case val.Kind() == reflect.String:
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{
+				StringValue: val.String(),
+			},
+		}
+	case typ.ConvertibleTo(reflect.TypeOf(time.Time{})):
+		valTime := val.Convert(reflect.TypeOf(time.Time{})).Interface().(time.Time)
+		if valTime.IsZero() {
+			return nil
+		}
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{
+				StringValue: valTime.Format(time.RFC3339Nano),
+			},
+		}
+	case (typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array) && typ.Elem() == reflect.TypeOf(byte(0)):
+		return byteSliceToAnyValue(val)
+	case typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array:
+		return sliceToAnyValue(val)
+	case typ.Kind() == reflect.Map:
+		return mapToAnyValue(val)
+	case typ.Kind() == reflect.Struct:
+		return structToAnyValue(typ, val)
+	default:
+		return &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{
+				StringValue: val.String(),
+			},
+		}
+	}
+}
+
+func byteSliceToAnyValue(val reflect.Value) *commonpb.AnyValue {
+	sliceLen := val.Len()
+	if sliceLen == 0 {
+		return nil
+	}
+	out := reflect.MakeSlice(reflect.SliceOf(reflect.TypeOf(byte(1))), sliceLen, sliceLen)
+	reflect.Copy(out, val)
+	return &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_BytesValue{
+			BytesValue: out.Interface().([]byte),
+		},
+	}
+}
+
+func sliceToAnyValue(val reflect.Value) *commonpb.AnyValue {
+	sliceLen := val.Len()
+	if sliceLen == 0 {
+		return nil
+	}
+	elems := make([]*commonpb.AnyValue, 0, sliceLen)
+	for i := 0; i < val.Len(); i++ {
+		elem := val.Index(i)
+		if !elem.CanInterface() {
+			continue
+		}
+		elems = append(elems, valueToAnyValue(elem.Interface()))
+	}
+	return &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: elems,
+			},
+		},
+	}
+}
+
+func structToAnyValue(typ reflect.Type, val reflect.Value) *commonpb.AnyValue {
+	nFields := typ.NumField()
+	attrs := make([]*commonpb.KeyValue, 0, nFields)
+	for i := 0; i < nFields; i++ {
+		fieldType := typ.Field(i)
+		if !fieldType.IsExported() {
+			continue
+		}
+		fieldValue := val.Field(i)
+		if !fieldValue.CanInterface() {
+			continue
+		}
+		fieldName := fieldType.Name
+		if jsonTag, exists := fieldType.Tag.Lookup("json"); exists {
+			fieldName = strings.Split(jsonTag, ",")[0]
+		}
+		fieldAnyValue := valueToAnyValue(fieldValue.Interface())
+		if fieldAnyValue == nil {
+			continue
+		}
+		attr := &commonpb.KeyValue{
+			Key:   fieldName,
+			Value: fieldAnyValue,
+		}
+		attrs = append(attrs, attr)
+	}
+	return &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_KvlistValue{
+			KvlistValue: &commonpb.KeyValueList{
+				Values: attrs,
+			},
+		},
+	}
+}
+
+func mapToAnyValue(val reflect.Value) *commonpb.AnyValue {
+	nFields := val.Len()
+	elems := make([]*commonpb.KeyValue, 0, nFields)
+	mapKeys := val.MapKeys()
+	sort.SliceStable(mapKeys, func(i, j int) bool {
+		return mapKeys[i].String() < mapKeys[j].String()
+	})
+	for _, mapKey := range mapKeys {
+		mapValue := val.MapIndex(mapKey)
+		if !mapValue.CanInterface() {
+			continue
+		}
+		mapValueAnyValue := valueToAnyValue(mapValue.Interface())
+		if mapValueAnyValue == nil {
+			continue
+		}
+		elem := &commonpb.KeyValue{
+			Key:   mapKey.String(),
+			Value: mapValueAnyValue,
+		}
+		elems = append(elems, elem)
+	}
+	return &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_KvlistValue{
+			KvlistValue: &commonpb.KeyValueList{
+				Values: elems,
+			},
+		},
+	}
+}
+
+func valueIsNil(typ reflect.Type, val reflect.Value) bool {
+	if typ == nil {
+		return true
+	}
+	switch val.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer,
+		reflect.Interface, reflect.Slice:
+		return val.IsNil()
+	default:
+		return false
+	}
 }

--- a/exporters/otlp/otlplogs/internal/logstransform/logs_test.go
+++ b/exporters/otlp/otlplogs/internal/logstransform/logs_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	"math"
 	"testing"
 	"time"
 )
@@ -34,12 +35,54 @@ func TestEmptyLogRecord(t *testing.T) {
 	assert.Nil(t, Logs([]logssdk.ReadableLogRecord{}))
 }
 
+type logStruct struct {
+	StringField     string
+	IntField        int
+	FloatField      float64 `json:"float_field"`
+	UintField       uint
+	BoolField       bool
+	TimeField       time.Time
+	BytesField      []byte
+	BytesArrayField [8]byte
+	SliceField      []logStruct
+	ArrayField      [1]*logStruct
+	MapField        map[string]any
+	StructField     *logStruct
+	NilField        *logStruct
+}
+
 func TestLogRecord(t *testing.T) {
 	//attrs := []attribute.KeyValue{attribute.Int("one", 1), attribute.Int("two", 2)}
 	//eventTime := time.Date(2020, 5, 20, 0, 0, 0, 0, time.UTC)
 
 	logTime := time.Unix(1589932800, 0000)
-	body := "message"
+	refTime := time.Now()
+	body := logStruct{
+		StringField:     "hello world",
+		IntField:        123,
+		FloatField:      3.14,
+		UintField:       math.MaxUint64,
+		BoolField:       true,
+		TimeField:       refTime,
+		BytesField:      []byte{1, 3, 5},
+		BytesArrayField: [8]byte{1, 3, 5},
+		SliceField: []logStruct{
+			{
+				StringField: "sliced_field_nested",
+			},
+		},
+		ArrayField: [1]*logStruct{},
+		MapField: map[string]any{
+			"first_key": "first_value",
+			"nested_key": map[string]any{
+				"second_key": "second_value",
+			},
+		},
+		StructField: &logStruct{
+			StringField: "hello world2",
+		},
+		NilField: nil,
+	}
 
 	lr := logRecord(logstest.LogRecordStub{
 		Timestamp:         &logTime,
@@ -49,7 +92,278 @@ func TestLogRecord(t *testing.T) {
 
 	logTimestamp := uint64(1589932800 * 1e9)
 
-	bodyValue := &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "message"}}
+	bodyValue := &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_KvlistValue{
+			KvlistValue: &commonpb.KeyValueList{
+				Values: []*commonpb.KeyValue{
+					{
+						Key: "StringField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_StringValue{
+								StringValue: body.StringField,
+							},
+						},
+					},
+					{
+						Key: "IntField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_IntValue{
+								IntValue: int64(body.IntField),
+							},
+						},
+					},
+					{
+						Key: "float_field",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_DoubleValue{
+								DoubleValue: body.FloatField,
+							},
+						},
+					},
+					{
+						Key: "UintField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_IntValue{
+								IntValue: math.MaxInt64,
+							},
+						},
+					},
+					{
+						Key: "BoolField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_BoolValue{
+								BoolValue: body.BoolField,
+							},
+						},
+					},
+					{
+						Key: "TimeField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_StringValue{
+								StringValue: body.TimeField.Format(time.RFC3339Nano),
+							},
+						},
+					},
+					{
+						Key: "BytesField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_BytesValue{
+								BytesValue: body.BytesField,
+							},
+						},
+					},
+					{
+						Key: "BytesArrayField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_BytesValue{
+								BytesValue: body.BytesArrayField[:],
+							},
+						},
+					},
+					{
+						Key: "SliceField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_ArrayValue{
+								ArrayValue: &commonpb.ArrayValue{
+									Values: []*commonpb.AnyValue{
+										{
+											Value: &commonpb.AnyValue_KvlistValue{
+												KvlistValue: &commonpb.KeyValueList{
+													Values: []*commonpb.KeyValue{
+														{
+															Key: "StringField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_StringValue{
+																	StringValue: body.SliceField[0].StringField,
+																},
+															},
+														},
+														{
+															Key: "IntField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_IntValue{
+																	IntValue: int64(body.SliceField[0].IntField),
+																},
+															},
+														},
+														{
+															Key: "float_field",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_DoubleValue{
+																	DoubleValue: body.SliceField[0].FloatField,
+																},
+															},
+														},
+														{
+															Key: "UintField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_IntValue{
+																	IntValue: int64(body.SliceField[0].UintField),
+																},
+															},
+														},
+														{
+															Key: "BoolField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_BoolValue{
+																	BoolValue: body.SliceField[0].BoolField,
+																},
+															},
+														},
+														{
+															Key: "BytesArrayField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_BytesValue{
+																	BytesValue: body.SliceField[0].BytesArrayField[:],
+																},
+															},
+														},
+														{
+															Key: "ArrayField",
+															Value: &commonpb.AnyValue{
+																Value: &commonpb.AnyValue_ArrayValue{
+																	ArrayValue: &commonpb.ArrayValue{
+																		Values: []*commonpb.AnyValue{
+																			nil,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Key: "ArrayField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_ArrayValue{
+								ArrayValue: &commonpb.ArrayValue{
+									Values: []*commonpb.AnyValue{
+										nil,
+									},
+								},
+							},
+						},
+					},
+					{
+						Key: "MapField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_KvlistValue{
+								KvlistValue: &commonpb.KeyValueList{
+									Values: []*commonpb.KeyValue{
+										{
+											Key: "first_key",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_StringValue{
+													StringValue: "first_value",
+												},
+											},
+										},
+										{
+											Key: "nested_key",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_KvlistValue{
+													KvlistValue: &commonpb.KeyValueList{
+														Values: []*commonpb.KeyValue{
+															{
+																Key: "second_key",
+																Value: &commonpb.AnyValue{
+																	Value: &commonpb.AnyValue_StringValue{
+																		StringValue: "second_value",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Key: "StructField",
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_KvlistValue{
+								KvlistValue: &commonpb.KeyValueList{
+									Values: []*commonpb.KeyValue{
+										{
+											Key: "StringField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_StringValue{
+													StringValue: body.StructField.StringField,
+												},
+											},
+										},
+										{
+											Key: "IntField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_IntValue{
+													IntValue: int64(body.StructField.IntField),
+												},
+											},
+										},
+										{
+											Key: "float_field",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_DoubleValue{
+													DoubleValue: body.StructField.FloatField,
+												},
+											},
+										},
+										{
+											Key: "UintField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_IntValue{
+													IntValue: int64(body.StructField.UintField),
+												},
+											},
+										},
+										{
+											Key: "BoolField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_BoolValue{
+													BoolValue: body.StructField.BoolField,
+												},
+											},
+										},
+										{
+											Key: "BytesArrayField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_BytesValue{
+													BytesValue: body.StructField.BytesArrayField[:],
+												},
+											},
+										},
+										{
+											Key: "ArrayField",
+											Value: &commonpb.AnyValue{
+												Value: &commonpb.AnyValue_ArrayValue{
+													ArrayValue: &commonpb.ArrayValue{
+														Values: []*commonpb.AnyValue{
+															nil,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	assert.Equal(t, &logspb.LogRecord{
 		Attributes:           nil,
 		Body:                 bodyValue,

--- a/exporters/stdout/stdoutlogs/stdout_record.go
+++ b/exporters/stdout/stdoutlogs/stdout_record.go
@@ -17,12 +17,14 @@ limitations under the License.
 package stdoutlogs
 
 import (
+	"fmt"
 	"github.com/agoda-com/opentelemetry-logs-go/logs"
 	sdk "github.com/agoda-com/opentelemetry-logs-go/sdk/logs"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
+	"reflect"
 	"time"
 )
 
@@ -81,7 +83,7 @@ func logRecordsFromReadableLogRecords(logRecords []sdk.ReadableLogRecord) []stdO
 			TraceFlags:           lr.TraceFlags(),
 			SeverityText:         lr.SeverityText(),
 			SeverityNumber:       lr.SeverityNumber(),
-			Body:                 lr.Body(),
+			Body:                 convertBodyToString(lr.Body()),
 			Resource:             lr.Resource(),
 			InstrumentationScope: lr.InstrumentationScope(),
 			Attributes:           lr.Attributes(),
@@ -89,4 +91,43 @@ func logRecordsFromReadableLogRecords(logRecords []sdk.ReadableLogRecord) []stdO
 		result = append(result, logRecord)
 	}
 	return result
+}
+
+func convertBodyToString(body any) *string {
+	typ := reflect.TypeOf(body)
+	val := reflect.ValueOf(body)
+	if valueIsNil(typ, val) {
+		return nil
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	}
+	if !val.CanInterface() {
+		return nil
+	}
+	var str string
+	switch {
+	case typ.ConvertibleTo(reflect.TypeOf(time.Time{})):
+		valTime := val.Convert(reflect.TypeOf(time.Time{})).Interface().(time.Time)
+		str = valTime.Format(time.RFC3339Nano)
+	case typ.Kind() == reflect.Struct:
+		str = fmt.Sprintf("%+v", val.Interface())
+	default:
+		str = fmt.Sprintf("%v", val.Interface())
+	}
+	return &str
+}
+
+func valueIsNil(typ reflect.Type, val reflect.Value) bool {
+	if typ == nil {
+		return true
+	}
+	switch val.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer,
+		reflect.Interface, reflect.Slice:
+		return val.IsNil()
+	default:
+		return false
+	}
 }

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -27,14 +27,16 @@ import (
 // LogRecordConfig contains mutable fields usable for constructing
 // an immutable LogRecord.
 type LogRecordConfig struct {
-	Timestamp            *time.Time
-	ObservedTimestamp    time.Time
-	TraceId              *trace.TraceID
-	SpanId               *trace.SpanID
-	TraceFlags           *trace.TraceFlags
-	SeverityText         *string
-	SeverityNumber       *SeverityNumber
+	Timestamp         *time.Time
+	ObservedTimestamp time.Time
+	TraceId           *trace.TraceID
+	SpanId            *trace.SpanID
+	TraceFlags        *trace.TraceFlags
+	SeverityText      *string
+	SeverityNumber    *SeverityNumber
+	// Deprecated: use BodyAny instead.
 	Body                 *string
+	BodyAny              any
 	Resource             *resource.Resource
 	InstrumentationScope *instrumentation.Scope
 	Attributes           *[]attribute.KeyValue
@@ -43,6 +45,9 @@ type LogRecordConfig struct {
 // NewLogRecord constructs a LogRecord using values from the provided
 // LogRecordConfig.
 func NewLogRecord(config LogRecordConfig) LogRecord {
+	if config.BodyAny == nil && config.Body != nil {
+		config.BodyAny = *config.Body
+	}
 	return LogRecord{
 		timestamp:            config.Timestamp,
 		observedTimestamp:    config.ObservedTimestamp,
@@ -51,7 +56,7 @@ func NewLogRecord(config LogRecordConfig) LogRecord {
 		traceFlags:           config.TraceFlags,
 		severityText:         config.SeverityText,
 		severityNumber:       config.SeverityNumber,
-		body:                 config.Body,
+		body:                 config.BodyAny,
 		resource:             config.Resource,
 		instrumentationScope: config.InstrumentationScope,
 		attributes:           config.Attributes,
@@ -69,7 +74,7 @@ type LogRecord struct {
 	traceFlags           *trace.TraceFlags
 	severityText         *string
 	severityNumber       *SeverityNumber
-	body                 *string
+	body                 any
 	resource             *resource.Resource
 	instrumentationScope *instrumentation.Scope
 	attributes           *[]attribute.KeyValue
@@ -82,7 +87,7 @@ func (l LogRecord) SpanId() *trace.SpanID                        { return l.span
 func (l LogRecord) TraceFlags() *trace.TraceFlags                { return l.traceFlags }
 func (l LogRecord) SeverityText() *string                        { return l.severityText }
 func (l LogRecord) SeverityNumber() *SeverityNumber              { return l.severityNumber }
-func (l LogRecord) Body() *string                                { return l.body }
+func (l LogRecord) Body() any                                    { return l.body }
 func (l LogRecord) Resource() *resource.Resource                 { return l.resource }
 func (l LogRecord) InstrumentationScope() *instrumentation.Scope { return l.instrumentationScope }
 func (l LogRecord) Attributes() *[]attribute.KeyValue            { return l.attributes }

--- a/sdk/logs/logger.go
+++ b/sdk/logs/logger.go
@@ -83,7 +83,7 @@ type ReadableLogRecord interface {
 	// SeverityNumber	Numerical value of the severityNumber.
 	SeverityNumber() *logs.SeverityNumber
 	// Body The body of the log record.
-	Body() *string
+	Body() any
 	// Resource 	Describes the source of the log.
 	Resource() *resource.Resource
 	// InstrumentationScope returns information about the instrumentation
@@ -117,7 +117,7 @@ type exportableLogRecord struct {
 	traceFlags           *trace.TraceFlags
 	severityText         *string
 	severityNumber       *logs.SeverityNumber
-	body                 *string
+	body                 any
 	resource             *resource.Resource
 	instrumentationScope *instrumentation.Scope
 	attributes           *[]attribute.KeyValue
@@ -174,10 +174,9 @@ func (r *exportableLogRecord) RecordException(message *string, stacktrace *strin
 	}
 }
 
-func (r *exportableLogRecord) Timestamp() *time.Time        { return r.timestamp }
-func (r *exportableLogRecord) ObservedTimestamp() time.Time { return r.observedTimestamp }
-func (r *exportableLogRecord) TraceId() *trace.TraceID      { return r.traceId }
-
+func (r *exportableLogRecord) Timestamp() *time.Time         { return r.timestamp }
+func (r *exportableLogRecord) ObservedTimestamp() time.Time  { return r.observedTimestamp }
+func (r *exportableLogRecord) TraceId() *trace.TraceID       { return r.traceId }
 func (r *exportableLogRecord) SpanId() *trace.SpanID         { return r.spanId }
 func (r *exportableLogRecord) TraceFlags() *trace.TraceFlags { return r.traceFlags }
 func (r *exportableLogRecord) InstrumentationScope() *instrumentation.Scope {
@@ -185,7 +184,7 @@ func (r *exportableLogRecord) InstrumentationScope() *instrumentation.Scope {
 }
 func (r *exportableLogRecord) SeverityText() *string                { return r.severityText }
 func (r *exportableLogRecord) SeverityNumber() *logs.SeverityNumber { return r.severityNumber }
-func (r *exportableLogRecord) Body() *string                        { return r.body }
+func (r *exportableLogRecord) Body() any                            { return r.body }
 func (r *exportableLogRecord) Resource() *resource.Resource         { return r.resource }
 func (r *exportableLogRecord) Attributes() *[]attribute.KeyValue    { return r.attributes }
 func (r *exportableLogRecord) private()                             {}

--- a/sdk/logs/logger_test.go
+++ b/sdk/logs/logger_test.go
@@ -66,6 +66,6 @@ func TestLogsReadWriteAPIFormat(t *testing.T) {
 		&timestamp,
 	)
 
-	assert.Equal(t, "My Log Message", *record.Body())
+	assert.Equal(t, "My Log Message", *(record.Body().(*string)))
 
 }

--- a/sdk/logs/logstest/log_record.go
+++ b/sdk/logs/logstest/log_record.go
@@ -35,7 +35,7 @@ type LogRecordStub struct {
 	TraceFlags           *trace.TraceFlags
 	SeverityText         *string
 	SeverityNumber       *logs.SeverityNumber
-	Body                 *string
+	Body                 any
 	Resource             *resource.Resource
 	InstrumentationScope *instrumentation.Scope
 	Attributes           *[]attribute.KeyValue
@@ -88,7 +88,7 @@ type logRecordSnapshot struct {
 	traceFlags           *trace.TraceFlags
 	severityText         *string
 	severityNumber       *logs.SeverityNumber
-	body                 *string
+	body                 any
 	resource             *resource.Resource
 	instrumentationScope *instrumentation.Scope
 	attributes           *[]attribute.KeyValue
@@ -104,6 +104,6 @@ func (r *logRecordSnapshot) InstrumentationScope() *instrumentation.Scope {
 }
 func (r *logRecordSnapshot) SeverityText() *string                { return r.severityText }
 func (r *logRecordSnapshot) SeverityNumber() *logs.SeverityNumber { return r.severityNumber }
-func (r *logRecordSnapshot) Body() *string                        { return r.body }
+func (r *logRecordSnapshot) Body() any                            { return r.body }
 func (r *logRecordSnapshot) Resource() *resource.Resource         { return r.resource }
 func (r *logRecordSnapshot) Attributes() *[]attribute.KeyValue    { return r.attributes }


### PR DESCRIPTION
Fixes #34, makes log record accept a body of the type [any](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body).